### PR TITLE
Add AN386 (Cortex-M4) + AN500 (Cortex-M7) support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "helight"]
 	path = slothy
 	url = https://github.com/slothy-optimizer/slothy
+[submodule "submodules/mbed-os"]
+	path = submodules/mbed-os
+	url = https://github.com/ARMmbed/mbed-os

--- a/envs/common/inc/hal.h
+++ b/envs/common/inc/hal.h
@@ -26,7 +26,14 @@
 #define MVE_POLY_ARITHMETIC_TESTS_HAL
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <hal_env.h>
+
+enum clock_mode {
+    CLOCK_FAST,
+    CLOCK_BENCHMARK
+};
+
 
 /* Request random data. */
 extern uint8_t get_random_byte();

--- a/envs/common/mps2.mk
+++ b/envs/common/mps2.mk
@@ -1,0 +1,89 @@
+CC = arm-none-eabi-gcc
+LD := $(CC)
+
+SRC_DIR=./src
+BUILD_DIR=./build/$(TARGET)
+
+COMMON_INC=../common/inc/
+ENV_INC=./inc/
+TEST_COMMON=../../tests/common/
+MBED_OS_DIR=../../submodules/mbed-os/
+
+
+MBED_OS_CMSIS = $(MBED_OS_DIR)/cmsis/CMSIS_5/CMSIS/TARGET_CORTEX_M/
+
+SYSROOT := $(shell $(CC) --print-sysroot)
+
+CFLAGS += \
+	-O3 \
+	-std=gnu99 \
+	--sysroot=$(SYSROOT) \
+	-Wall -Wextra -Wshadow -Werror \
+	-MMD \
+	-fno-common \
+	-I$(COMMON_INC) \
+	-I$(ENV_INC) \
+	-I$(SRC_DIR) \
+	-I$(TESTDIR) \
+	-I$(MBED_OS_CMSIS)/Include \
+	-I$(MBED_OS_TARGET_DIR) \
+	-I$(TEST_COMMON)
+
+CFLAGS += \
+	$(ARCH_FLAGS) \
+	--specs=nosys.specs
+
+LDFLAGS += \
+	-Wl,--wrap=_sbrk \
+	-Wl,--wrap=_open \
+	-Wl,--wrap=_close \
+	-Wl,--wrap=_isatty \
+	-Wl,--wrap=_kill \
+	-Wl,--wrap=_lseek \
+	-Wl,--wrap=_read \
+	-Wl,--wrap=_write \
+	-Wl,--wrap=_fstat \
+	-Wl,--wrap=_getpid \
+	--specs=nosys.specs \
+	-T$(LDSCRIPT) \
+	$(ARCH_FLAGS)
+
+all: $(TARGET)
+
+HAL_SOURCES = ../common/src/hal-mps2.c
+HAL_ASMS = $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+OBJECTS_HAL = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(HAL_SOURCES)))
+OBJECTS_HAL += $(patsubst %.S, $(BUILD_DIR)/%.S.o, $(abspath $(HAL_ASMS)))
+OBJECTS_SOURCES=$(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(SOURCES)))
+OBJECTS_C = $(OBJECTS_SOURCES) $(OBJECTS_HAL) $(OBJECTS_TEST_COMMON)
+OBJECTS_ASM = $(patsubst %.s, $(BUILD_DIR)/%.s.o, $(abspath $(ASMS)))
+
+OBJECTS = $(OBJECTS_C) $(OBJECTS_ASM)
+
+$(OBJECTS_C): $(BUILD_DIR)/%.o: %
+	mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(OBJECTS_ASM): $(BUILD_DIR)/%.o: %
+	mkdir -p $(@D)
+	$(CC) -x assembler-with-cpp $(CFLAGS) -c -o $@ $<
+
+$(TARGET): $(OBJECTS) $(LDSCRIPT)
+	$(LD) $(LDFLAGS) -o $@ $(OBJECTS)
+
+.PHONY: build
+build: $(TARGET)
+
+run: $(TARGET)
+	qemu-system-arm -M $(QEMU_PLATFORM) -nographic -semihosting -kernel $(TARGET)
+
+check: $(TARGET)
+	qemu-system-arm -M $(QEMU_PLATFORM) -nographic -semihosting -kernel $(TARGET) | tail -n 2 | grep "ALL GOOD!" || exit 1
+
+$(LDSCRIPT): $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld
+	[ -d $(@D) ] || $(Q)mkdir -p $(@D); \
+	$(CC) -x assembler-with-cpp -E -Wp,-P $(CFLAGS) $< -o $@
+
+clean:
+	rm -f *.elf
+	rm -rf $(BUILD_DIR)

--- a/envs/common/src/hal-mps2.c
+++ b/envs/common/src/hal-mps2.c
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <stdarg.h>
+#include <stdio.h>
+#include <hal.h>
+#if defined(MPS2_AN385)
+#include <CMSDK_CM3.h>
+#elif defined(MPS2_AN386)
+#include <CMSDK_CM4.h>
+#elif defined(MPS2_AN500)
+#include <CMSDK_CM7.h>
+#else
+#error Unsupported mps2 board
+#endif
+
+#define BAUD 38400
+
+/* Default clock on the MPS2 boards seems to be 25MHz */
+#ifndef SYSTEM_CLOCK
+#define SYSTEM_CLOCK 25000000UL
+#endif
+
+/* The startup file calls a SystemInit function. */
+void SystemInit(void) {
+    /* Enable the FPU */
+    SCB->CPACR |= ((3UL << 10 * 2) |               /* set CP10 Full Access */
+                   (3UL << 11 * 2));               /* set CP11 Full Access */
+    /* Enable UART */
+    /* TODO: Validate this on a *real* MPS2 board (works in QEMU) */
+    CMSDK_GPIO0->ALTFUNCSET |= 1u;
+    CMSDK_GPIO0->ALTFUNCSET |= 2u;
+    CMSDK_UART0->BAUDDIV = SYSTEM_CLOCK / BAUD;
+    CMSDK_UART0->CTRL |= 1 << CMSDK_UART_CTRL_RXEN_Pos;
+    CMSDK_UART0->CTRL |= 1 << CMSDK_UART_CTRL_TXEN_Pos;
+    /* Enable SysTick Timer */
+    SysTick->LOAD = 0xFFFFFFu;
+    NVIC_SetPriority(SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL);
+    NVIC_EnableIRQ(SysTick_IRQn);
+    SysTick->VAL = 0UL;
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
+}
+
+static volatile unsigned long long overflowcnt = 0;
+
+/* SysTick Interrupt */
+void SysTick_Handler(void) {
+    ++overflowcnt;
+}
+
+uint64_t hal_get_time() {
+    while (1) {
+        unsigned long long before = overflowcnt;
+        unsigned long long result = (before + 1) * 16777216llu - SysTick->VAL;
+        if (overflowcnt == before) {
+            return result;
+        }
+    }
+}
+
+void hal_setup(const enum clock_mode clock) {
+    (void) clock;
+}
+
+static inline void uart_putc(int c) {
+    while (CMSDK_UART0->STATE & CMSDK_UART_STATE_TXBF_Msk);
+    CMSDK_UART0->DATA = c & 0xFFu;
+}
+
+void hal_send_str(const char *in) {
+    const char *cur = in;
+    while (*cur) {
+        uart_putc(*cur);
+        cur += 1;
+    }
+    uart_putc('\n');
+}
+
+
+void debug_test_start( const char *testname ){
+    hal_setup(CLOCK_BENCHMARK);
+    hal_send_str(testname);
+    hal_send_str("...");
+}
+
+void debug_printf(const char * format, ... )
+{
+    char str[100];
+    va_list argp;
+    va_start( argp, format );
+    vsnprintf(str, sizeof str, format, argp );
+    va_end( argp );
+    hal_send_str(str);
+}
+
+
+void debug_test_ok()   { hal_send_str( "Ok\n"    ); }
+void debug_test_fail() { hal_send_str( "FAIL!\n" ); }
+
+#if !defined(NO_SEMIHOSTING_EXIT)
+// TODO(dsprenkels) Currently, we only exit the QEMU host when a the program
+// exists successfully.  We should also populate some interrupts handlers that
+// occur on errors and/or other exception.
+
+// These two syscall values are used at the end of the program, when we want
+// to tell the QEMU host that we are done.  I took them from
+// <https://github.com/rust-embedded/cortex-m-semihosting/blob/8ab74cdb8c9ab669ded328072447ea6f6054ffe6/src/debug.rs#L25-L50>.
+static const uint32_t REPORT_EXCEPTION = 0x18;
+static const uint32_t ApplicationExit = 0x20026;
+
+// Do a system call towards QEMU or the debugger.
+static uint32_t semihosting_syscall(uint32_t nr, const uint32_t arg) {
+    __asm__ volatile (
+        "mov r0, %[nr]\n"
+        "mov r1, %[arg]\n"
+        "bkpt 0xAB\n"
+        "mov %[nr], r0\n"
+        : [nr] "+r" (nr) : [arg] "r" (arg) : "0", "1");
+    return nr;
+}
+
+// Register a destructor that will call qemu telling them that the program
+// has exited successfully.
+static void __attribute__ ((destructor)) semihosting_exit(void) {
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void NMI_Handler(void) {
+    hal_send_str("NMI_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void HardFault_Handler(void) {
+    hal_send_str("HardFault_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void MemManage_Handler(void) {
+    hal_send_str("MemManage_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void BusFault_Handler(void) {
+    hal_send_str("BusFault_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void UsageFault_Handler(void) {
+    hal_send_str("UsageFault_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void SVC_Handler(void) {
+    hal_send_str("SVC_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void DebugMon_Handler(void) {
+    hal_send_str("DebugMon_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void PendSV_Handler(void) {
+    hal_send_str("PendSV_Handler");
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+void Default_Handler(void) {
+    semihosting_syscall(REPORT_EXCEPTION, ApplicationExit);
+}
+
+#endif /* !defined(NO_SEMIHOSTING_EXIT) */
+
+/* End of BSS is where the heap starts (defined in the linker script) */
+extern char end;
+static char *heap_end = &end;
+
+void *__wrap__sbrk (int incr) {
+    char *prev_heap_end;
+
+    prev_heap_end = heap_end;
+    heap_end += incr;
+
+    return (void *) prev_heap_end;
+}
+
+size_t hal_get_stack_size(void) {
+    register char *cur_stack;
+    __asm__ volatile ("mov %0, sp" : "=r" (cur_stack));
+    return cur_stack - heap_end;
+}
+
+const uint32_t stackpattern = 0xDEADBEEFlu;
+
+static void *last_sp = NULL;
+
+void hal_spraystack(void) {
+
+    char *_heap_end = heap_end;
+    asm volatile ("mov %0, sp\n"
+                  ".L%=:\n\t"
+                  "str %2, [%1], #4\n\t"
+                  "cmp %1, %0\n\t"
+                  "blt .L%=\n\t"
+                  : "+r" (last_sp), "+r" (_heap_end) : "r" (stackpattern) : "cc", "memory");
+}
+
+size_t hal_checkstack(void) {
+    size_t result = 0;
+    asm volatile("sub %0, %1, %2\n"
+                 ".L%=:\n\t"
+                 "ldr ip, [%2], #4\n\t"
+                 "cmp ip, %3\n\t"
+                 "ite eq\n\t"
+                 "subeq %0, #4\n\t"
+                 "bne .LE%=\n\t"
+                 "cmp %2, %1\n\t"
+                 "blt .L%=\n\t"
+                 ".LE%=:\n"
+                 : "+r"(result) : "r" (last_sp), "r" (heap_end), "r" (stackpattern) : "ip", "cc");
+    return result;
+}
+
+/* Implement some system calls to shut up the linker warnings */
+
+#include <errno.h>
+#undef errno
+extern int errno;
+
+int __wrap__open(char *file, int flags, int mode) {
+    (void) file;
+    (void) flags;
+    (void) mode;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__close(int fd) {
+    errno = ENOSYS;
+    (void) fd;
+    return -1;
+}
+
+#include <sys/stat.h>
+
+int __wrap__fstat(int fd, struct stat *buf) {
+    (void) fd;
+    (void) buf;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__getpid(void) {
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__isatty(int file) {
+    (void) file;
+    errno = ENOSYS;
+    return 0;
+}
+
+int __wrap__kill(int pid, int sig) {
+    (void) pid;
+    (void) sig;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__lseek(int fd, int ptr, int dir) {
+    (void) fd;
+    (void) ptr;
+    (void) dir;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__read(int fd, char *ptr, int len) {
+    (void) fd;
+    (void) ptr;
+    (void) len;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__write(int fd, const char *ptr, int len) {
+    (void) fd;
+    (void) ptr;
+    (void) len;
+    errno = ENOSYS;
+    return -1;
+}

--- a/envs/m4-an386/Makefile
+++ b/envs/m4-an386/Makefile
@@ -1,0 +1,100 @@
+# Makefile for images for AN386
+
+CC = arm-none-eabi-gcc
+LD := $(CC)
+
+SRC_DIR=./src
+BUILD_DIR=./build/$(TARGET)
+
+
+
+COMMON_INC=../common/inc/
+ENV_INC=./inc/
+TEST_COMMON=../../tests/common/
+MBED_OS_DIR=../../submodules/mbed-os/
+
+MBED_OS_TARGET_DIR = $(MBED_OS_DIR)/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device
+MBED_OS_CMSIS = $(MBED_OS_DIR)/cmsis/CMSIS_5/CMSIS/TARGET_CORTEX_M/
+
+
+
+ARCH_FLAGS += -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
+LDSCRIPT = $(BUILD_DIR)/generated.M4.ld
+
+SYSROOT := $(shell $(CC) --print-sysroot)
+
+CFLAGS += \
+	-O3 \
+	-std=gnu99 \
+	--sysroot=$(SYSROOT) \
+	-Wall -Wextra -Wshadow -Werror \
+	-MMD \
+	-fno-common \
+	-I$(COMMON_INC) \
+	-I$(ENV_INC) \
+	-I$(SRC_DIR) \
+	-I$(TESTDIR) \
+	-I$(MBED_OS_CMSIS)/Include \
+	-I$(MBED_OS_TARGET_DIR) \
+	-I$(TEST_COMMON) \
+
+CFLAGS += \
+ 	-DMPS2 -DMPS2_AN386 \
+	$(ARCH_FLAGS) \
+	--specs=nosys.specs
+
+LDFLAGS += \
+	-Wl,--wrap=_sbrk \
+	-Wl,--wrap=_open \
+	-Wl,--wrap=_close \
+	-Wl,--wrap=_isatty \
+	-Wl,--wrap=_kill \
+	-Wl,--wrap=_lseek \
+	-Wl,--wrap=_read \
+	-Wl,--wrap=_write \
+	-Wl,--wrap=_fstat \
+	-Wl,--wrap=_getpid \
+	--specs=nosys.specs \
+	-T$(LDSCRIPT) \
+	$(ARCH_FLAGS)
+
+all: $(TARGET)
+
+HAL_SOURCES = ../common/src/hal-mps2.c
+HAL_ASMS = $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+OBJECTS_HAL = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(HAL_SOURCES)))
+OBJECTS_HAL += $(patsubst %.S, $(BUILD_DIR)/%.S.o, $(abspath $(HAL_ASMS)))
+OBJECTS_SOURCES=$(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(SOURCES)))
+OBJECTS_C = $(OBJECTS_SOURCES) $(OBJECTS_HAL) $(OBJECTS_TEST_COMMON)
+OBJECTS_ASM = $(patsubst %.s, $(BUILD_DIR)/%.s.o, $(abspath $(ASMS)))
+
+OBJECTS = $(OBJECTS_C) $(OBJECTS_ASM)
+
+$(OBJECTS_C): $(BUILD_DIR)/%.o: %
+	mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(OBJECTS_ASM): $(BUILD_DIR)/%.o: %
+	mkdir -p $(@D)
+	$(CC) -x assembler-with-cpp $(CFLAGS) -c -o $@ $<
+
+$(TARGET): $(OBJECTS) $(LDSCRIPT)
+	$(LD) $(LDFLAGS) -o $@ $(OBJECTS)
+
+.PHONY: build
+build: $(TARGET)
+
+run: $(TARGET)
+	qemu-system-arm -M mps2-an386 -nographic -semihosting -kernel $(TARGET)
+
+check: $(TARGET)
+	qemu-system-arm -M mps2-an386 -nographic -semihosting -kernel $(TARGET) | tail -n 2 | grep "ALL GOOD!" || exit 1
+
+
+$(LDSCRIPT): $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld
+	[ -d $(@D) ] || $(Q)mkdir -p $(@D); \
+	$(CC) -x assembler-with-cpp -E -Wp,-P $(CFLAGS) $< -o $@
+
+clean: 
+	rm -f *.elf
+	rm -rf $(BUILD_DIR)

--- a/envs/m4-an386/Makefile
+++ b/envs/m4-an386/Makefile
@@ -1,96 +1,10 @@
 # Makefile for images for AN386
 
-CC = arm-none-eabi-gcc
-LD := $(CC)
-
-SRC_DIR=./src
-BUILD_DIR=./build/$(TARGET)
-
-COMMON_INC=../common/inc/
-ENV_INC=./inc/
-TEST_COMMON=../../tests/common/
-MBED_OS_DIR=../../submodules/mbed-os/
-
 MBED_OS_TARGET_DIR = $(MBED_OS_DIR)/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device
-MBED_OS_CMSIS = $(MBED_OS_DIR)/cmsis/CMSIS_5/CMSIS/TARGET_CORTEX_M/
 
 ARCH_FLAGS += -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
 LDSCRIPT = $(BUILD_DIR)/generated.M4.ld
+CFLAGS += -DMPS2 -DMPS2_AN386
+QEMU_PLATFORM = mps2-an386
 
-SYSROOT := $(shell $(CC) --print-sysroot)
-
-CFLAGS += \
-	-O3 \
-	-std=gnu99 \
-	--sysroot=$(SYSROOT) \
-	-Wall -Wextra -Wshadow -Werror \
-	-MMD \
-	-fno-common \
-	-I$(COMMON_INC) \
-	-I$(ENV_INC) \
-	-I$(SRC_DIR) \
-	-I$(TESTDIR) \
-	-I$(MBED_OS_CMSIS)/Include \
-	-I$(MBED_OS_TARGET_DIR) \
-	-I$(TEST_COMMON) \
-
-CFLAGS += \
- 	-DMPS2 -DMPS2_AN386 \
-	$(ARCH_FLAGS) \
-	--specs=nosys.specs
-
-LDFLAGS += \
-	-Wl,--wrap=_sbrk \
-	-Wl,--wrap=_open \
-	-Wl,--wrap=_close \
-	-Wl,--wrap=_isatty \
-	-Wl,--wrap=_kill \
-	-Wl,--wrap=_lseek \
-	-Wl,--wrap=_read \
-	-Wl,--wrap=_write \
-	-Wl,--wrap=_fstat \
-	-Wl,--wrap=_getpid \
-	--specs=nosys.specs \
-	-T$(LDSCRIPT) \
-	$(ARCH_FLAGS)
-
-all: $(TARGET)
-
-HAL_SOURCES = ../common/src/hal-mps2.c
-HAL_ASMS = $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/startup_MPS2.S
-OBJECTS_HAL = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(HAL_SOURCES)))
-OBJECTS_HAL += $(patsubst %.S, $(BUILD_DIR)/%.S.o, $(abspath $(HAL_ASMS)))
-OBJECTS_SOURCES=$(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(SOURCES)))
-OBJECTS_C = $(OBJECTS_SOURCES) $(OBJECTS_HAL) $(OBJECTS_TEST_COMMON)
-OBJECTS_ASM = $(patsubst %.s, $(BUILD_DIR)/%.s.o, $(abspath $(ASMS)))
-
-OBJECTS = $(OBJECTS_C) $(OBJECTS_ASM)
-
-$(OBJECTS_C): $(BUILD_DIR)/%.o: %
-	mkdir -p $(@D)
-	$(CC) $(CFLAGS) -c -o $@ $<
-
-$(OBJECTS_ASM): $(BUILD_DIR)/%.o: %
-	mkdir -p $(@D)
-	$(CC) -x assembler-with-cpp $(CFLAGS) -c -o $@ $<
-
-$(TARGET): $(OBJECTS) $(LDSCRIPT)
-	$(LD) $(LDFLAGS) -o $@ $(OBJECTS)
-
-.PHONY: build
-build: $(TARGET)
-
-run: $(TARGET)
-	qemu-system-arm -M mps2-an386 -nographic -semihosting -kernel $(TARGET)
-
-check: $(TARGET)
-	qemu-system-arm -M mps2-an386 -nographic -semihosting -kernel $(TARGET) | tail -n 2 | grep "ALL GOOD!" || exit 1
-
-
-$(LDSCRIPT): $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld
-	[ -d $(@D) ] || $(Q)mkdir -p $(@D); \
-	$(CC) -x assembler-with-cpp -E -Wp,-P $(CFLAGS) $< -o $@
-
-clean:
-	rm -f *.elf
-	rm -rf $(BUILD_DIR)
+include ../common/mps2.mk

--- a/envs/m4-an386/inc/hal_env.h
+++ b/envs/m4-an386/inc/hal_env.h
@@ -1,0 +1,6 @@
+#if !defined(ARCHEX_HAL_ENV_HDR)
+#define ARCHEX_HAL_ENV_HDR
+
+/* Nothing in the HAL is implemented through macros. */
+
+#endif /* ARCHEX_HAL_ENV_HDR */

--- a/envs/m55-an547/Makefile
+++ b/envs/m55-an547/Makefile
@@ -52,7 +52,7 @@ LDFLAGS += \
 
 all: $(TARGET)
 
-HAL_SOURCES = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/*/*.c) $(wildcard ../common/src/*.c)
+HAL_SOURCES = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/*/*.c)
 OBJECTS_HAL = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(HAL_SOURCES)))
 TEST_COMMON_SOURCES = $(wildcard $(TEST_COMMON)/*.c) 
 OBJECTS_TEST_COMMON = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(TEST_COMMON_SOURCES)))

--- a/envs/m7-an500/Makefile
+++ b/envs/m7-an500/Makefile
@@ -1,4 +1,4 @@
-# Makefile for images for AN386
+# Makefile for images for AN500
 
 CC = arm-none-eabi-gcc
 LD := $(CC)
@@ -11,11 +11,11 @@ ENV_INC=./inc/
 TEST_COMMON=../../tests/common/
 MBED_OS_DIR=../../submodules/mbed-os/
 
-MBED_OS_TARGET_DIR = $(MBED_OS_DIR)/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device
+MBED_OS_TARGET_DIR = $(MBED_OS_DIR)/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device
 MBED_OS_CMSIS = $(MBED_OS_DIR)/cmsis/CMSIS_5/CMSIS/TARGET_CORTEX_M/
 
-ARCH_FLAGS += -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
-LDSCRIPT = $(BUILD_DIR)/generated.M4.ld
+ARCH_FLAGS += -mcpu=cortex-m7 -mthumb -mfloat-abi=hard -mfpu=fpv5-d16
+LDSCRIPT = $(BUILD_DIR)/generated.M7.ld
 
 SYSROOT := $(shell $(CC) --print-sysroot)
 
@@ -35,7 +35,7 @@ CFLAGS += \
 	-I$(TEST_COMMON) \
 
 CFLAGS += \
- 	-DMPS2 -DMPS2_AN386 \
+ 	-DMPS2 -DMPS2_AN500 \
 	$(ARCH_FLAGS) \
 	--specs=nosys.specs
 
@@ -81,10 +81,10 @@ $(TARGET): $(OBJECTS) $(LDSCRIPT)
 build: $(TARGET)
 
 run: $(TARGET)
-	qemu-system-arm -M mps2-an386 -nographic -semihosting -kernel $(TARGET)
+	qemu-system-arm -M mps2-an500 -nographic -semihosting -kernel $(TARGET)
 
 check: $(TARGET)
-	qemu-system-arm -M mps2-an386 -nographic -semihosting -kernel $(TARGET) | tail -n 2 | grep "ALL GOOD!" || exit 1
+	qemu-system-arm -M mps2-an500 -nographic -semihosting -kernel $(TARGET) | tail -n 2 | grep "ALL GOOD!" || exit 1
 
 
 $(LDSCRIPT): $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld

--- a/envs/m7-an500/Makefile
+++ b/envs/m7-an500/Makefile
@@ -1,96 +1,10 @@
 # Makefile for images for AN500
 
-CC = arm-none-eabi-gcc
-LD := $(CC)
-
-SRC_DIR=./src
-BUILD_DIR=./build/$(TARGET)
-
-COMMON_INC=../common/inc/
-ENV_INC=./inc/
-TEST_COMMON=../../tests/common/
-MBED_OS_DIR=../../submodules/mbed-os/
-
 MBED_OS_TARGET_DIR = $(MBED_OS_DIR)/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device
-MBED_OS_CMSIS = $(MBED_OS_DIR)/cmsis/CMSIS_5/CMSIS/TARGET_CORTEX_M/
 
 ARCH_FLAGS += -mcpu=cortex-m7 -mthumb -mfloat-abi=hard -mfpu=fpv5-d16
 LDSCRIPT = $(BUILD_DIR)/generated.M7.ld
+CFLAGS += -DMPS2 -DMPS2_AN500
+QEMU_PLATFORM = mps2-an500
 
-SYSROOT := $(shell $(CC) --print-sysroot)
-
-CFLAGS += \
-	-O3 \
-	-std=gnu99 \
-	--sysroot=$(SYSROOT) \
-	-Wall -Wextra -Wshadow -Werror \
-	-MMD \
-	-fno-common \
-	-I$(COMMON_INC) \
-	-I$(ENV_INC) \
-	-I$(SRC_DIR) \
-	-I$(TESTDIR) \
-	-I$(MBED_OS_CMSIS)/Include \
-	-I$(MBED_OS_TARGET_DIR) \
-	-I$(TEST_COMMON) \
-
-CFLAGS += \
- 	-DMPS2 -DMPS2_AN500 \
-	$(ARCH_FLAGS) \
-	--specs=nosys.specs
-
-LDFLAGS += \
-	-Wl,--wrap=_sbrk \
-	-Wl,--wrap=_open \
-	-Wl,--wrap=_close \
-	-Wl,--wrap=_isatty \
-	-Wl,--wrap=_kill \
-	-Wl,--wrap=_lseek \
-	-Wl,--wrap=_read \
-	-Wl,--wrap=_write \
-	-Wl,--wrap=_fstat \
-	-Wl,--wrap=_getpid \
-	--specs=nosys.specs \
-	-T$(LDSCRIPT) \
-	$(ARCH_FLAGS)
-
-all: $(TARGET)
-
-HAL_SOURCES = ../common/src/hal-mps2.c
-HAL_ASMS = $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/startup_MPS2.S
-OBJECTS_HAL = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(HAL_SOURCES)))
-OBJECTS_HAL += $(patsubst %.S, $(BUILD_DIR)/%.S.o, $(abspath $(HAL_ASMS)))
-OBJECTS_SOURCES=$(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(SOURCES)))
-OBJECTS_C = $(OBJECTS_SOURCES) $(OBJECTS_HAL) $(OBJECTS_TEST_COMMON)
-OBJECTS_ASM = $(patsubst %.s, $(BUILD_DIR)/%.s.o, $(abspath $(ASMS)))
-
-OBJECTS = $(OBJECTS_C) $(OBJECTS_ASM)
-
-$(OBJECTS_C): $(BUILD_DIR)/%.o: %
-	mkdir -p $(@D)
-	$(CC) $(CFLAGS) -c -o $@ $<
-
-$(OBJECTS_ASM): $(BUILD_DIR)/%.o: %
-	mkdir -p $(@D)
-	$(CC) -x assembler-with-cpp $(CFLAGS) -c -o $@ $<
-
-$(TARGET): $(OBJECTS) $(LDSCRIPT)
-	$(LD) $(LDFLAGS) -o $@ $(OBJECTS)
-
-.PHONY: build
-build: $(TARGET)
-
-run: $(TARGET)
-	qemu-system-arm -M mps2-an500 -nographic -semihosting -kernel $(TARGET)
-
-check: $(TARGET)
-	qemu-system-arm -M mps2-an500 -nographic -semihosting -kernel $(TARGET) | tail -n 2 | grep "ALL GOOD!" || exit 1
-
-
-$(LDSCRIPT): $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld
-	[ -d $(@D) ] || $(Q)mkdir -p $(@D); \
-	$(CC) -x assembler-with-cpp -E -Wp,-P $(CFLAGS) $< -o $@
-
-clean:
-	rm -f *.elf
-	rm -rf $(BUILD_DIR)
+include ../common/mps2.mk

--- a/envs/m7-an500/inc/hal_env.h
+++ b/envs/m7-an500/inc/hal_env.h
@@ -1,0 +1,6 @@
+#if !defined(ARCHEX_HAL_ENV_HDR)
+#define ARCHEX_HAL_ENV_HDR
+
+/* Nothing in the HAL is implemented through macros. */
+
+#endif /* ARCHEX_HAL_ENV_HDR */

--- a/envs/m85-an555/Makefile
+++ b/envs/m85-an555/Makefile
@@ -53,7 +53,7 @@ LDFLAGS += \
 
 all: $(TARGET)
 
-HAL_SOURCES = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/*/*.c) $(wildcard ../common/src/*.c)
+HAL_SOURCES = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/*/*.c)
 OBJECTS_HAL = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(HAL_SOURCES)))
 TEST_COMMON_SOURCES = $(wildcard $(TEST_COMMON)/*.c) 
 OBJECTS_TEST_COMMON = $(patsubst %.c, $(BUILD_DIR)/%.c.o, $(abspath $(TEST_COMMON_SOURCES)))

--- a/tests/helloworld/helloworld.mk
+++ b/tests/helloworld/helloworld.mk
@@ -7,6 +7,7 @@ TESTS += helloworld
 HELLOWORLD_PLATFORMS += m55-an547
 HELLOWORLD_PLATFORMS += m85-an555
 HELLOWORLD_PLATFORMS += m4-an386
+HELLOWORLD_PLATFORMS += m7-an500
 
 # C sources required for this test
 HELLOWORLD_SOURCES += main.c

--- a/tests/helloworld/helloworld.mk
+++ b/tests/helloworld/helloworld.mk
@@ -6,6 +6,7 @@ TESTS += helloworld
 # Platforms this test should run on (matching the directory name in envs/)
 HELLOWORLD_PLATFORMS += m55-an547
 HELLOWORLD_PLATFORMS += m85-an555
+HELLOWORLD_PLATFORMS += m4-an386
 
 # C sources required for this test
 HELLOWORLD_SOURCES += main.c

--- a/tests/helloworld/main.c
+++ b/tests/helloworld/main.c
@@ -30,10 +30,13 @@ void mve_test( void *src, uint16_t *dst );
 
 int main (void)
 {
+
+    #if defined(__ARM_FEATURE_MVE)
     uint16_t test_vector[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
     uint16_t sum;
+    #endif
 
-#if defined(EXEC_TB)
+#if defined(EXEC_TB) && defined(__ARM_FEATURE_MVE)
     EXECTB_Init();
     enableCde();
     initTick();
@@ -42,6 +45,7 @@ int main (void)
     /* Test preamble */
     debug_test_start( "Hello World!" );
 
+    #if defined(__ARM_FEATURE_MVE)
     measure_start();
     mve_test( test_vector, &sum );
     measure_end();
@@ -51,6 +55,7 @@ int main (void)
         debug_test_fail();
         return( 1 );
     }
+    #endif
 
     debug_test_ok();
     debug_printf( "ALL GOOD!\n" );

--- a/tests/helloworld/mve_test.s
+++ b/tests/helloworld/mve_test.s
@@ -22,6 +22,8 @@
  *
  */
 
+
+#if defined(__ARM_FEATURE_MVE)
 .syntax unified
 .type mve_test, %function
 .global mve_test
@@ -37,3 +39,4 @@ mve_test:
         vpop {d0-d1}
         pop {r4}
         bx lr
+#endif


### PR DESCRIPTION
Based on https://github.com/pq-code-package/mlkem-c-embedded which in turn uses the HAL files from https://github.com/ARMmbed/mbed-os (Arm probably has those hosted somewhere elso too, but I don't quite understand their CMSIS repos -- this one just works fine). 

So far this only runs the helloworld test. 

Real code will be added separately (see https://github.com/slothy-optimizer/pqmx/tree/armv7m). 
I'll add the STM32 platforms in a follow-up PR which will include benchmarking.