### PR TITLE
Add pyserial and coreutils to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,10 +44,13 @@
                 };
               });
 
+              inherit (pkgs.python311Packages)
+                pyserial;
               inherit (pkgs)
                 direnv
                 nix-direnv
                 openocd
+                coreutils
                 qemu
                 ;
             };


### PR DESCRIPTION
A fresh macOS doesn't have `nproc` by default, which is needed in CI and makefile (e.g. `make -jnproc`). 

`nproc` is equipped in the nixpkgs `coreutils`.
