### PR TITLE
RELICENSE: Add frame for gathering consent to relicensing

### DIFF
--- a/RELICENSE
+++ b/RELICENSE
@@ -1,0 +1,15 @@
+# Relicensing
+
+This document gathers consent by copyright holders of the slothy-optimizer/pqmx
+repository to relicense their contributions to `Apache-2.0 OR ISC OR MIT`.
+
+The relicensing itself is intended to be carried out once all copyright
+holders have given their consent.
+
+## Copyright holders agreeing to relicensing
+
+By adding my name to the list below, I agree to relicensing
+of my contributions in the slothy-optimizer/pqmx repository
+to `Apache-2.0 OR ISC OR MIT`.
+
+- Hanno Becker <beckphan@amazon.co.uk>


### PR DESCRIPTION
This commit adds RELICENSE, where copyright holders of the slothy-optimizer/pqmx can give consent to the relicensing under `Apache-2.0 OR ISC OR MIT`.