### PR TITLE
Fix compiler warnings to enable clean builds with -Werror

### DIFF
--- a/asm/manual/crt/crt.s
+++ b/asm/manual/crt/crt.s
@@ -604,7 +604,7 @@ crt_s32_dechunk_chunk_add:
         ldr init_tmp, [addr], #+4
         vdup.u32 qmask, init_tmp
         /* Save size, original destination pointer and mask for later */
-        push {size, dst, init_tmp}
+        push {dst, size, init_tmp}
         ldrd mod_p, mod_q_neg, [addr], #+8
         ldrd p_inv_mod_q, p_inv_mod_q_tw, [addr], #+8
         vdup.u32 mod_p_vect, mod_p
@@ -861,7 +861,7 @@ crt_s32_dechunk_chunk:
         ldr init_tmp, [addr], #+4
         vdup.u32 qmask, init_tmp
         /* Save size, original destination pointer and mask for later */
-        push {size, dst, init_tmp}
+        push {dst, size, init_tmp}
         ldrd mod_p, mod_q_neg, [addr], #+8
         ldrd p_inv_mod_q, p_inv_mod_q_tw, [addr], #+8
         vdup.u32 mod_p_vect, mod_p
@@ -1794,7 +1794,7 @@ crt_s32_chunk_dechunk_reduce_canonical_v2:
         ldr init_tmp, [addr], #+4
         vdup.u32 qmask, init_tmp
         /* Save size, original destination pointer and mask for later */
-        push {size, dst, init_tmp}
+        push {dst, size, init_tmp}
         ldrd mod_p, mod_q_neg, [addr], #+8
         ldrd p_inv_mod_q, p_inv_mod_q_tw, [addr], #+8
         vdup.u32 mod_p_vect, mod_p
@@ -1835,7 +1835,7 @@ crt_s32_chunk_dechunk_reduce_canonical_v2:
          * Iterate over them in scalar for reduction to canonical form. */
 
         /* Restore mask and original destination pointer */
-        pop {size, dst, mask}
+        pop {dst, size, mask}
         mov rcarry, #0
         mov loop_cnt, size, LSR #1
         wls loop_cnt, loop_cnt, 2
@@ -1939,7 +1939,7 @@ crt_s32_chunk_dechunk_sub_reduce_canonical_v2:
         ldr init_tmp, [addr], #+4
         vdup.u32 qmask, init_tmp
         /* Save size, original destination pointer and mask for later */
-        push {size, dst, init_tmp}
+        push {dst, size, init_tmp}
         ldrd mod_p, mod_q_neg, [addr], #+8
         ldrd p_inv_mod_q, p_inv_mod_q_tw, [addr], #+8
         vdup.u32 mod_p_vect, mod_p
@@ -2014,7 +2014,7 @@ crt_s32_chunk_dechunk_sub_reduce_canonical_v2:
          * Iterate over them in scalar for reduction to canonical form. */
 
         /* Restore mask and original destination pointer */
-        pop {size, dst, mask}
+        pop {dst, size, mask}
         mov rcarry, #0
         mov loop_cnt, size, LSR #1
         wls loop_cnt, loop_cnt, 2
@@ -2118,7 +2118,7 @@ crt_s32_chunk_dechunk_sub_reduce_canonical_v3:
         ldr init_tmp, [addr], #+4
         vdup.u32 qmask, init_tmp
         /* Save size, original destination pointer and mask for later */
-        push {size, dst, init_tmp}
+        push {dst, size, init_tmp}
         ldrd mod_p, mod_q_neg, [addr], #+8
         ldrd p_inv_mod_q, p_inv_mod_q_tw, [addr], #+8
         vdup.u32 mod_p_vect, mod_p
@@ -2240,7 +2240,7 @@ crt_s32_chunk_dechunk_sub_reduce_canonical_v3:
         /* At this point, we have non-canonical limbs of 32-bit.
         * Iterate over them in scalar for reduction to canonical form. */
         /* Restore mask and original destination pointer */
-        pop {size, dst, mask}
+        pop {dst, size, mask}
         mov rcarry, #0
         mov loop_cnt, size, LSR #1
         wls loop_cnt, loop_cnt, 2
@@ -2347,7 +2347,7 @@ crt_s32_chunk_dechunk_add_reduce_canonical:
         ldr init_tmp, [addr], #+4
         vdup.u32 qmask, init_tmp
         /* Save size, original destination pointer and mask for later */
-        push {size, dst, init_tmp}
+        push {dst, size, init_tmp}
         ldrd mod_p, mod_q_neg, [addr], #+8
         ldrd p_inv_mod_q, p_inv_mod_q_tw, [addr], #+8
         vdup.u32 mod_p_vect, mod_p
@@ -2469,7 +2469,7 @@ crt_s32_chunk_dechunk_add_reduce_canonical:
         /* At this point, we have non-canonical limbs of 32-bit.
         * Iterate over them in scalar for reduction to canonical form. */
         /* Restore mask and original destination pointer */
-        pop {size, dst, mask}
+        pop {dst, size, mask}
         mov rcarry, #0
         mov loop_cnt, size, LSR #1
         wls loop_cnt, loop_cnt, 2

--- a/asm/manual/karatsuba/karatsuba.s
+++ b/asm/manual/karatsuba/karatsuba.s
@@ -493,6 +493,7 @@ karatsuba_inv_dual_32_loop:
         f_even_odd  .req q2
         f_sum_odd   .req q3
 
+        #undef SHIFT
         #define SHIFT 0
 
         sum_even  .req q7 // alloc q7

--- a/envs/m55-an547/Makefile
+++ b/envs/m55-an547/Makefile
@@ -13,7 +13,7 @@ TEST_COMMON=../../tests/common/
 SYSROOT := $(shell $(CC) --print-sysroot)
 CFLAGS += \
 	-O3 \
-	-Wall -Wextra -Wshadow \
+	-Wall -Wextra -Wshadow -Werror \
 	-fno-common \
 	-ffunction-sections \
 	-fdata-sections \

--- a/envs/m55-an547/src/hal.c
+++ b/envs/m55-an547/src/hal.c
@@ -127,39 +127,39 @@ void hal_pmu_finish_pmu_stats( pmu_stats *s )
 void hal_pmu_send_stats( char *s, pmu_stats const *stats )
 {
     printf( "%s\n", s );
-    printf( "- cycles:               %u\n",                            stats->pmu_cycles );
-    printf( "- systick cycles:       %u\n",                            stats->systick_cycles );
-    printf( "- instructions:         %u (IPC=0.%u)\n",                 stats->inst_all,
-            ( stats->inst_all * 100 ) / stats->pmu_cycles );
-    printf( "- stalls:               %u (%u%% of instructions)\n",     stats->stall_all,
-            ( stats->stall_all * 100 ) / stats->inst_all );
-    printf( "- MVE instructions:     %u (%u%% of instructions)\n",     stats->inst_mve_all,
-            ( stats->inst_mve_all * 100) / stats->inst_all );
-    printf( "- MVE LSU instructions: %u (%u%% of MVE instructions, busy %u%% of cycles)\n", stats->inst_mve_lsu,
-            ( stats->inst_mve_lsu * 100) / stats->inst_mve_all,
-            ( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles );
-    printf( "- MVE INT instructions: %u (%u%% of MVE instructions, busy %u%% of cycles)\n", stats->inst_mve_int,
-            ( stats->inst_mve_int * 100) / stats->inst_mve_all,
-            ( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles );
-    printf( "- MVE MUL instructions: %u (%u%% of MVE instructions, busy %u%% of cycles)\n", stats->inst_mve_mul,
-            ( stats->inst_mve_mul * 100) / stats->inst_mve_all,
-            ( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles );
-    printf( "- MVE stalls:           %u (%u%% of MVE instructions)\n", stats->stall_mve_all,
-            ( stats->stall_mve_all * 100 ) / stats->inst_mve_all );
-    printf( "- MVE resource stalls:  %u (%u%% of MVE stalls)\n",       stats->stall_mve_resource,
-            ( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
+    printf( "- cycles:               %lu\n",                            (unsigned long)stats->pmu_cycles );
+    printf( "- systick cycles:       %lu\n",                            (unsigned long)stats->systick_cycles );
+    printf( "- instructions:         %lu (IPC=0.%lu)\n",                 (unsigned long)stats->inst_all,
+            (unsigned long)( stats->inst_all * 100 ) / stats->pmu_cycles );
+    printf( "- stalls:               %lu (%lu%% of instructions)\n",     (unsigned long)stats->stall_all,
+            (unsigned long)( stats->stall_all * 100 ) / stats->inst_all );
+    printf( "- MVE instructions:     %lu (%lu%% of instructions)\n",     (unsigned long)stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_all * 100) / stats->inst_all );
+    printf( "- MVE LSU instructions: %lu (%lu%% of MVE instructions, busy %lu%% of cycles)\n", (unsigned long)stats->inst_mve_lsu,
+            (unsigned long)( stats->inst_mve_lsu * 100) / stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles );
+    printf( "- MVE INT instructions: %lu (%lu%% of MVE instructions, busy %lu%% of cycles)\n", (unsigned long)stats->inst_mve_int,
+            (unsigned long)( stats->inst_mve_int * 100) / stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles );
+    printf( "- MVE MUL instructions: %lu (%lu%% of MVE instructions, busy %lu%% of cycles)\n", (unsigned long)stats->inst_mve_mul,
+            (unsigned long)( stats->inst_mve_mul * 100) / stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles );
+    printf( "- MVE stalls:           %lu (%lu%% of MVE instructions)\n", (unsigned long)stats->stall_mve_all,
+            (unsigned long)( stats->stall_mve_all * 100 ) / stats->inst_mve_all );
+    printf( "- MVE resource stalls:  %lu (%lu%% of MVE stalls)\n",       (unsigned long)stats->stall_mve_resource,
+            (unsigned long)( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
 
-    printf( "s %u  %u %u  %u %u  %u %u  %u %u %u  %u %u %u  %u %u %u  %u %u  %u %u\n",
+    printf( "s %s  %lu %lu  %lu %lu  %lu %lu  %lu %lu %lu  %lu %lu %lu  %lu %lu %lu  %lu %lu  %lu %lu %lu\n",
             s,
-            stats->pmu_cycles,
-            stats->inst_all,           ( stats->inst_all           * 100 ) / stats->pmu_cycles,
-            stats->stall_all,          ( stats->stall_all          * 100 ) / stats->inst_all,
-            stats->inst_mve_all,       ( stats->inst_mve_all       * 100 ) / stats->inst_all,
-            stats->inst_mve_lsu,       ( stats->inst_mve_lsu       * 100 ) / stats->inst_mve_all,      ( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles,
-            stats->inst_mve_int,       ( stats->inst_mve_int       * 100 ) / stats->inst_mve_all,      ( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles,
-            stats->inst_mve_mul,       ( stats->inst_mve_mul       * 100 ) / stats->inst_mve_all,      ( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles,
-            stats->stall_mve_all,      ( stats->stall_mve_all      * 100 ) / stats->inst_mve_all,
-            stats->stall_mve_resource, ( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
+            (unsigned long)stats->pmu_cycles,
+            (unsigned long)stats->inst_all,           (unsigned long)( stats->inst_all           * 100 ) / stats->pmu_cycles,
+            (unsigned long)stats->stall_all,          (unsigned long)( stats->stall_all          * 100 ) / stats->inst_all,
+            (unsigned long)stats->inst_mve_all,       (unsigned long)( stats->inst_mve_all       * 100 ) / stats->inst_all,
+            (unsigned long)stats->inst_mve_lsu,       (unsigned long)( stats->inst_mve_lsu       * 100 ) / stats->inst_mve_all,      (unsigned long)( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles,
+            (unsigned long)stats->inst_mve_int,       (unsigned long)( stats->inst_mve_int       * 100 ) / stats->inst_mve_all,      (unsigned long)( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles,
+            (unsigned long)stats->inst_mve_mul,       (unsigned long)( stats->inst_mve_mul       * 100 ) / stats->inst_mve_all,      (unsigned long)( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles,
+            (unsigned long)stats->stall_mve_all,      (unsigned long)( stats->stall_mve_all      * 100 ) / stats->inst_mve_all,
+            (unsigned long)stats->stall_mve_resource, (unsigned long)( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
 
 }
 

--- a/envs/m85-an555/Makefile
+++ b/envs/m85-an555/Makefile
@@ -14,7 +14,7 @@ TEST_COMMON=../../tests/common/
 SYSROOT := $(shell $(CC) --print-sysroot)
 CFLAGS += \
 	-O3 \
-	-Wall -Wextra -Wshadow \
+	-Wall -Wextra -Wshadow -Werror \
 	-fno-common \
 	-ffunction-sections \
 	-fdata-sections \

--- a/envs/m85-an555/src/hal.c
+++ b/envs/m85-an555/src/hal.c
@@ -176,38 +176,38 @@ void hal_pmu_finish_pmu_stats( pmu_stats *s )
 void hal_pmu_send_stats( char *s, pmu_stats const *stats )
 {
     printf( "%s\n", s );
-    printf( "- cycles:               %u\n",                            stats->pmu_cycles );
-    printf( "- systick cycles:       %u\n",                            stats->systick_cycles );
-    printf( "- instructions:         %u (IPC=0.%u)\n",                 stats->inst_all,
-            ( stats->inst_all * 100 ) / stats->pmu_cycles );
-    printf( "- stalls:               %u (%u%% of instructions)\n",     stats->stall_all,
-            ( stats->stall_all * 100 ) / stats->inst_all );
-    printf( "- MVE instructions:     %u (%u%% of instructions)\n",     stats->inst_mve_all,
-            ( stats->inst_mve_all * 100) / stats->inst_all );
-    printf( "- MVE LSU instructions: %u (%u%% of MVE instructions, busy %u%% of cycles)\n", stats->inst_mve_lsu,
-            ( stats->inst_mve_lsu * 100) / stats->inst_mve_all,
-            ( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles );
-    printf( "- MVE INT instructions: %u (%u%% of MVE instructions, busy %u%% of cycles)\n", stats->inst_mve_int,
-            ( stats->inst_mve_int * 100) / stats->inst_mve_all,
-            ( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles );
-    printf( "- MVE MUL instructions: %u (%u%% of MVE instructions, busy %u%% of cycles)\n", stats->inst_mve_mul,
-            ( stats->inst_mve_mul * 100) / stats->inst_mve_all,
-            ( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles );
-    printf( "- MVE stalls:           %u (%u%% of MVE instructions)\n", stats->stall_mve_all,
-            ( stats->stall_mve_all * 100 ) / stats->inst_mve_all );
-    printf( "- MVE resource stalls:  %u (%u%% of MVE stalls)\n",       stats->stall_mve_resource,
-            ( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
+    printf( "- cycles:               %lu\n",                            (unsigned long)stats->pmu_cycles );
+    printf( "- systick cycles:       %lu\n",                            (unsigned long)stats->systick_cycles );
+    printf( "- instructions:         %lu (IPC=0.%lu)\n",                 (unsigned long)stats->inst_all,
+            (unsigned long)( stats->inst_all * 100 ) / stats->pmu_cycles );
+    printf( "- stalls:               %lu (%lu%% of instructions)\n",     (unsigned long)stats->stall_all,
+            (unsigned long)( stats->stall_all * 100 ) / stats->inst_all );
+    printf( "- MVE instructions:     %lu (%lu%% of instructions)\n",     (unsigned long)stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_all * 100) / stats->inst_all );
+    printf( "- MVE LSU instructions: %lu (%lu%% of MVE instructions, busy %lu%% of cycles)\n", (unsigned long)stats->inst_mve_lsu,
+            (unsigned long)( stats->inst_mve_lsu * 100) / stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles );
+    printf( "- MVE INT instructions: %lu (%lu%% of MVE instructions, busy %lu%% of cycles)\n", (unsigned long)stats->inst_mve_int,
+            (unsigned long)( stats->inst_mve_int * 100) / stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles );
+    printf( "- MVE MUL instructions: %lu (%lu%% of MVE instructions, busy %lu%% of cycles)\n", (unsigned long)stats->inst_mve_mul,
+            (unsigned long)( stats->inst_mve_mul * 100) / stats->inst_mve_all,
+            (unsigned long)( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles );
+    printf( "- MVE stalls:           %lu (%lu%% of MVE instructions)\n", (unsigned long)stats->stall_mve_all,
+            (unsigned long)( stats->stall_mve_all * 100 ) / stats->inst_mve_all );
+    printf( "- MVE resource stalls:  %lu (%lu%% of MVE stalls)\n",       (unsigned long)stats->stall_mve_resource,
+            (unsigned long)( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
 
-    printf( "s %u  %u %u  %u %u  %u %u  %u %u %u  %u %u %u  %u %u %u  %u %u  %u %u\n",
+    printf( "s %s  %lu %lu  %lu %lu  %lu %lu  %lu %lu %lu  %lu %lu %lu  %lu %lu %lu  %lu %lu  %lu %lu %lu\n",
             s,
-            stats->pmu_cycles,
-            stats->inst_all,           ( stats->inst_all           * 100 ) / stats->pmu_cycles,
-            stats->stall_all,          ( stats->stall_all          * 100 ) / stats->inst_all,
-            stats->inst_mve_all,       ( stats->inst_mve_all       * 100 ) / stats->inst_all,
-            stats->inst_mve_lsu,       ( stats->inst_mve_lsu       * 100 ) / stats->inst_mve_all,      ( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles,
-            stats->inst_mve_int,       ( stats->inst_mve_int       * 100 ) / stats->inst_mve_all,      ( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles,
-            stats->inst_mve_mul,       ( stats->inst_mve_mul       * 100 ) / stats->inst_mve_all,      ( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles,
-            stats->stall_mve_all,      ( stats->stall_mve_all      * 100 ) / stats->inst_mve_all,
-            stats->stall_mve_resource, ( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
+            (unsigned long)stats->pmu_cycles,
+            (unsigned long)stats->inst_all,           (unsigned long)( stats->inst_all           * 100 ) / stats->pmu_cycles,
+            (unsigned long)stats->stall_all,          (unsigned long)( stats->stall_all          * 100 ) / stats->inst_all,
+            (unsigned long)stats->inst_mve_all,       (unsigned long)( stats->inst_mve_all       * 100 ) / stats->inst_all,
+            (unsigned long)stats->inst_mve_lsu,       (unsigned long)( stats->inst_mve_lsu       * 100 ) / stats->inst_mve_all,      (unsigned long)( stats->inst_mve_lsu * 2 * 100) / stats->pmu_cycles,
+            (unsigned long)stats->inst_mve_int,       (unsigned long)( stats->inst_mve_int       * 100 ) / stats->inst_mve_all,      (unsigned long)( stats->inst_mve_int * 2 * 100) / stats->pmu_cycles,
+            (unsigned long)stats->inst_mve_mul,       (unsigned long)( stats->inst_mve_mul       * 100 ) / stats->inst_mve_all,      (unsigned long)( stats->inst_mve_mul * 2 * 100) / stats->pmu_cycles,
+            (unsigned long)stats->stall_mve_all,      (unsigned long)( stats->stall_mve_all      * 100 ) / stats->inst_mve_all,
+            (unsigned long)stats->stall_mve_resource, (unsigned long)( stats->stall_mve_resource * 100 ) / stats->stall_mve_all );
 
 }

--- a/tests/common/poly.h
+++ b/tests/common/poly.h
@@ -119,8 +119,8 @@ void mod_mul_buf_s16      ( int16_t *src_a, int16_t *src_b, int16_t *dst,
 #define MAKE_SCHOOLBOOK_(BITWIDTH,DIM)                                   \
 void C_SCHOOLBOOK_SYMBOL_NAME(BITWIDTH,DIM)                              \
         ( uint(BITWIDTH)        *r,                                      \
-          uint(BITWIDTH) const  *a,                                      \
-          uint(BITWIDTH) const  *b )                                     \
+          uint(BITWIDTH) const  *src_a,                                  \
+          uint(BITWIDTH) const  *src_b )                                 \
     {                                                                    \
         unsigned i, j;                                                   \
                                                                          \
@@ -133,8 +133,8 @@ void C_SCHOOLBOOK_SYMBOL_NAME(BITWIDTH,DIM)                              \
             {                                                            \
                 r[SCHOOLBOOK_OFFSET_FROM_INDEX_DST(DIM, i+j)]            \
                     +=   SCHOOLBOOK_FACTOR(DIM, i+j)                     \
-                    * a[SCHOOLBOOK_OFFSET_FROM_INDEX_SRCA(DIM, i)]       \
-                    * b[SCHOOLBOOK_OFFSET_FROM_INDEX_SRCB(DIM, j)];      \
+                    * src_a[SCHOOLBOOK_OFFSET_FROM_INDEX_SRCA(DIM, i)]   \
+                    * src_b[SCHOOLBOOK_OFFSET_FROM_INDEX_SRCB(DIM, j)];  \
             }                                                            \
         }                                                                \
     }

--- a/tests/common/poly.h
+++ b/tests/common/poly.h
@@ -197,8 +197,7 @@ void C_SCHOOLBOOK_VARSIZE_SYMBOL_NAME(BITWIDTH_IN,BITWIDTH_OUT,DIM)      \
 void C_SCHOOLBOOK_VARSIZE_SYMBOL_NAME(BITWIDTH_IN,BITWIDTH_OUT,DIM)      \
         ( uint(BITWIDTH_OUT)        *r,                                  \
           uint(BITWIDTH_IN)  const  *a,                                  \
-          uint(BITWIDTH_IN)  const  *b,                                  \
-          uint(BITWIDTH_IN) modulus )                                    \
+          uint(BITWIDTH_IN)  const  *b )                                 \
     {                                                                    \
         unsigned i, j;                                                   \
                                                                          \

--- a/tests/crt/main.c
+++ b/tests/crt/main.c
@@ -108,8 +108,8 @@ int check_crt_s32_single()
 
     int32_t x, y, zp, zq;
     int64_t z;
-    fill_random_u32( &x, 1 );
-    fill_random_u32( &y, 1 );
+    fill_random_u32( (uint32_t*)&x, 1 );
+    fill_random_u32( (uint32_t*)&y, 1 );
 
     x = mod_s32( x, CRT_32_P );
     y = mod_s32( y, CRT_32_Q );
@@ -165,8 +165,8 @@ int test_crt_s32()
     int64_t out    [CRT_32_SIZE];
     int64_t out_ref[CRT_32_SIZE];
 
-    fill_random_u32( inQ, CRT_32_SIZE );
-    fill_random_u32( inP, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inQ, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inP, CRT_32_SIZE );
     for( unsigned idx=0; idx < CRT_32_SIZE; idx++ )
     {
         inP[idx] >>= 1;
@@ -190,7 +190,6 @@ int test_crt_s32()
         int32_t x, y, zp, zq;
         int64_t z;
         uint64_t z_abs;
-        uint32_t x_abs, y_abs;
 
         x = inP[idx];
         y = inQ[idx];
@@ -200,14 +199,6 @@ int test_crt_s32()
             z_abs = z;
         else
             z_abs = -z;
-        if( x > 0 )
-            x_abs = x;
-        else
-            x_abs = -x;
-        if( y > 0 )
-            y_abs = y;
-        else
-            y_abs = -y;
 
         zp = mod_s64( z, CRT_32_P );
         zq = mod_s64( z, CRT_32_Q );
@@ -280,8 +271,8 @@ int test_crt_s32_reduce()
     int64_t out    [CRT_32_SIZE];
     int64_t out_ref[CRT_32_SIZE];
 
-    fill_random_u32( inQ, CRT_32_SIZE );
-    fill_random_u32( inP, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inQ, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inP, CRT_32_SIZE );
     for( unsigned idx=0; idx < CRT_32_SIZE; idx++ )
     {
         inQ[idx] >>= 1;
@@ -306,7 +297,6 @@ int test_crt_s32_reduce()
         int32_t x, y, zp, zq;
         int64_t z;
         uint64_t z_abs;
-        uint32_t x_abs, y_abs;
 
         x = inP[idx];
         y = inQ[idx];
@@ -316,14 +306,6 @@ int test_crt_s32_reduce()
             z_abs = z;
         else
             z_abs = -z;
-        if( x > 0 )
-            x_abs = x;
-        else
-            x_abs = -x;
-        if( y > 0 )
-            y_abs = y;
-        else
-            y_abs = -y;
 
         zp = mod_s64( z, CRT_32_P );
         zq = mod_s64( z, CRT_32_Q );
@@ -422,12 +404,10 @@ int test_crt_s32_chunk_dechunk_reduce()
     int32_t inQ    [CRT_32_SIZE];
     int32_t out    [CRT_32_SIZE];
     int32_t out_ref [CRT_32_SIZE];
-    int32_t out_ref2[CRT_32_SIZE];
-    int64_t out_tmp_mve[CRT_32_SIZE];
     int64_t out_tmp_C  [CRT_32_SIZE];
 
-    fill_random_u32( inQ, CRT_32_SIZE );
-    fill_random_u32( inP, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inQ, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inP, CRT_32_SIZE );
     for( unsigned i=0; i < CRT_32_SIZE; i++ )
     {
         inP[i] >>= 1;
@@ -440,12 +420,12 @@ int test_crt_s32_chunk_dechunk_reduce()
     measure_start();
     crt_s32_chunk_dechunk_reduce( out, inP, inQ, CRT_32_SIZE );
     measure_end();
-    chunk_dechunk_22_s32_to_32( out, out, CRT_32_SIZE );
+    chunk_dechunk_22_s32_to_32( (uint32_t*)out, out, CRT_32_SIZE );
 
     mod_buf_s32( inP, CRT_32_SIZE, CRT_32_P );
     mod_buf_s32( inQ, CRT_32_SIZE, CRT_32_Q );
     crt_s32_C( out_tmp_C, inP, inQ, CRT_32_P, CRT_32_Q, CRT_32_P_INV_MOD_Q, CRT_32_SIZE );
-    chunk_dechunk_22_s64_to_32( out_ref, out_tmp_C, CRT_32_SIZE );
+    chunk_dechunk_22_s64_to_32( (uint32_t*)out_ref, out_tmp_C, CRT_32_SIZE );
 
     if( compare_buf_s32( out_ref, out, CRT_32_SIZE ) != 0 )
     {
@@ -477,12 +457,10 @@ int test_crt_s32_chunk_dechunk()
     int32_t inQ    [CRT_32_SIZE];
     int32_t out    [CRT_32_SIZE];
     int32_t out_ref [CRT_32_SIZE];
-    int32_t out_ref2[CRT_32_SIZE];
-    int64_t out_tmp_mve[CRT_32_SIZE];
     int64_t out_tmp_C  [CRT_32_SIZE];
 
-    fill_random_u32( inQ, CRT_32_SIZE );
-    fill_random_u32( inP, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inQ, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inP, CRT_32_SIZE );
     for( unsigned i=0; i < CRT_32_SIZE; i++ )
     {
         inP[i] >>= 1;
@@ -498,10 +476,10 @@ int test_crt_s32_chunk_dechunk()
     measure_start();
     crt_s32_chunk_dechunk( out, inP, inQ, CRT_32_SIZE );
     measure_end();
-    chunk_dechunk_22_s32_to_32( out, out, CRT_32_SIZE );
+    chunk_dechunk_22_s32_to_32( (uint32_t*)out, out, CRT_32_SIZE );
 
     crt_s32_C( out_tmp_C, inP, inQ, CRT_32_P, CRT_32_Q, CRT_32_P_INV_MOD_Q, CRT_32_SIZE );
-    chunk_dechunk_22_s64_to_32( out_ref, out_tmp_C, CRT_32_SIZE );
+    chunk_dechunk_22_s64_to_32( (uint32_t*)out_ref, out_tmp_C, CRT_32_SIZE );
 
     if( compare_buf_s32( out_ref, out, CRT_32_SIZE ) != 0 )
     {
@@ -533,12 +511,10 @@ int test_crt_s32_chunk_dechunk_reduce_canonical()
     int32_t inQ    [CRT_32_SIZE];
     int32_t out    [CRT_32_SIZE];
     int32_t out_ref [CRT_32_SIZE];
-    int32_t out_ref2[CRT_32_SIZE];
-    int64_t out_tmp_mve[CRT_32_SIZE];
     int64_t out_tmp_C  [CRT_32_SIZE];
 
-    fill_random_u32( inQ, CRT_32_SIZE );
-    fill_random_u32( inP, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inQ, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inP, CRT_32_SIZE );
     for( unsigned i=0; i < CRT_32_SIZE; i++ )
     {
         inP[i] >>= 1;
@@ -555,7 +531,7 @@ int test_crt_s32_chunk_dechunk_reduce_canonical()
     mod_buf_s32( inP, CRT_32_SIZE, CRT_32_P );
     mod_buf_s32( inQ, CRT_32_SIZE, CRT_32_Q );
     crt_s32_C( out_tmp_C, inP, inQ, CRT_32_P, CRT_32_Q, CRT_32_P_INV_MOD_Q, CRT_32_SIZE );
-    chunk_dechunk_22_s64_to_32( out_ref, out_tmp_C, CRT_32_SIZE );
+    chunk_dechunk_22_s64_to_32( (uint32_t*)out_ref, out_tmp_C, CRT_32_SIZE );
 
     if( compare_buf_s32( out_ref, out, CRT_32_SIZE ) != 0 )
     {
@@ -585,12 +561,10 @@ int test_crt_s32_chunk_dechunk_reduce_canonical_v2()
     int32_t inQ    [CRT_32_SIZE];
     int32_t out    [CRT_32_SIZE];
     int32_t out_ref [CRT_32_SIZE];
-    int32_t out_ref2[CRT_32_SIZE];
-    int64_t out_tmp_mve[CRT_32_SIZE];
     int64_t out_tmp_C  [CRT_32_SIZE];
 
-    fill_random_u32( inQ, CRT_32_SIZE );
-    fill_random_u32( inP, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inQ, CRT_32_SIZE );
+    fill_random_u32( (uint32_t*)inP, CRT_32_SIZE );
     for( unsigned i=0; i < CRT_32_SIZE; i++ )
     {
         inP[i] >>= 1;
@@ -607,7 +581,7 @@ int test_crt_s32_chunk_dechunk_reduce_canonical_v2()
     mod_buf_s32( inP, CRT_32_SIZE, CRT_32_P );
     mod_buf_s32( inQ, CRT_32_SIZE, CRT_32_Q );
     crt_s32_C( out_tmp_C, inP, inQ, CRT_32_P, CRT_32_Q, CRT_32_P_INV_MOD_Q, CRT_32_SIZE );
-    chunk_dechunk_22_s64_to_32( out_ref, out_tmp_C, CRT_32_SIZE );
+    chunk_dechunk_22_s64_to_32( (uint32_t*)out_ref, out_tmp_C, CRT_32_SIZE );
 
     if( compare_buf_s32( out_ref, out, CRT_32_SIZE ) != 0 )
     {

--- a/tests/flt-fft/main.c
+++ b/tests/flt-fft/main.c
@@ -51,8 +51,8 @@ void hal_pmu_send_stats( char *s, pmu_stats const *stats );
     fun( src, tw, SIZE);                                                \
     if( memcmp( src, res, sizeof( src ) ) != 0 )                        \
     {                                                                   \
-        debug_print_buf_s32( src, SIZE, "src" );                        \
-        debug_print_buf_s32( res, SIZE, "res" );                        \
+        debug_print_buf_u32( src, SIZE, "src" );                        \
+        debug_print_buf_u32( res, SIZE, "res" );                        \
         debug_printf( "FUNCTIONAL ERROR!\n" );                          \
         return 1;                                                       \
     }                                                                   \

--- a/tests/fx-fft/main.c
+++ b/tests/fx-fft/main.c
@@ -51,8 +51,8 @@ void hal_pmu_send_stats( char *s, pmu_stats const *stats );
     fun( src, tw, SIZE);                                                \
     if( memcmp( src, res, sizeof( src ) ) != 0 )                        \
     {                                                                   \
-        debug_print_buf_s32( src, SIZE, "src" );                        \
-        debug_print_buf_s32( res, SIZE, "res" );                        \
+        debug_print_buf_u32( src, SIZE, "src" );                        \
+        debug_print_buf_u32( res, SIZE, "res" );                        \
         debug_printf( "FUNCTIONAL ERROR!\n" );                          \
         return 1;                                                       \
     }                                                                   \

--- a/tests/intmulntt/main.c
+++ b/tests/intmulntt/main.c
@@ -162,7 +162,7 @@ void poly_u22_mul_mve( uint64_t c[2*NUM_CHUNKS],
     }
 
     /* CRT */
-    crt_s32_pure_reduce( c, ntt_p, ntt_q, CRT_32_SIZE );
+    crt_s32_pure_reduce( (int64_t*)c, (int32_t*)ntt_p, (int32_t*)ntt_q, CRT_32_SIZE );
 }
 
 void int_mul_mve_chunked_u22( uint32_t c[2*NUM_CHUNKS],
@@ -194,7 +194,7 @@ void int_mul_mve_chunked_u22( uint32_t c[2*NUM_CHUNKS],
     }
 
     /* CRT */
-    crt_s32_chunk_dechunk_reduce_canonical( c, ntt_p, ntt_q, CRT_32_SIZE );
+    crt_s32_chunk_dechunk_reduce_canonical( (int32_t*)c, (int32_t*)ntt_p, (int32_t*)ntt_q, CRT_32_SIZE );
 }
 
 void sub_s32( int32_t *src, int32_t *a, int32_t *b, size_t size )
@@ -411,7 +411,6 @@ int test_intchunkmulsub()
     uint32_t c      [2*NUM_CHUNKS];
     uint32_t c0_ref [2*NUM_CHUNKS];
     uint64_t c0_tmp [2*NUM_CHUNKS];
-    uint32_t c1     [2*NUM_CHUNKS];
     uint32_t c1_ref [2*NUM_CHUNKS];
     uint64_t c1_tmp [2*NUM_CHUNKS];
     uint32_t c_ref  [2*NUM_CHUNKS];
@@ -434,12 +433,12 @@ int test_intchunkmulsub()
     poly_u22_mul_C( c1_tmp, a1, b1 );
     chunk_dechunk_22_64_to_32( c1_ref, c1_tmp, 2 * NUM_CHUNKS );
 
-    sub_s32( c0_ref, c0_ref, c1_ref, 2 * NUM_CHUNKS );
-    chunk_dechunk_22_s32_to_s32( c_ref, c0_ref, 2 * NUM_CHUNKS );
+    sub_s32( (int32_t*)c0_ref, (int32_t*)c0_ref, (int32_t*)c1_ref, 2 * NUM_CHUNKS );
+    chunk_dechunk_22_s32_to_s32( (int32_t*)c_ref, (int32_t*)c0_ref, 2 * NUM_CHUNKS );
 
     /* Step 2: NTT-based multiplication */
     measure_start();
-    int_mulsub_mve_chunked_u22( c, a0, b0, a1, b1 );
+    int_mulsub_mve_chunked_u22( (int32_t*)c, a0, b0, a1, b1 );
     measure_end();
 
     /* Step 3: Compare results */
@@ -477,7 +476,6 @@ int test_intchunkmuladd()
     uint32_t c      [2*NUM_CHUNKS];
     uint32_t c0_ref [2*NUM_CHUNKS];
     uint64_t c0_tmp [2*NUM_CHUNKS];
-    uint32_t c1     [2*NUM_CHUNKS];
     uint32_t c1_ref [2*NUM_CHUNKS];
     uint64_t c1_tmp [2*NUM_CHUNKS];
     uint32_t c_ref  [2*NUM_CHUNKS];
@@ -500,12 +498,12 @@ int test_intchunkmuladd()
     poly_u22_mul_C( c1_tmp, a1, b1 );
     chunk_dechunk_22_64_to_32( c1_ref, c1_tmp, 2 * NUM_CHUNKS );
 
-    add_s32( c0_ref, c0_ref, c1_ref, 2 * NUM_CHUNKS );
-    chunk_dechunk_22_s32_to_s32( c_ref, c0_ref, 2 * NUM_CHUNKS );
+    add_s32( (int32_t*)c0_ref, (int32_t*)c0_ref, (int32_t*)c1_ref, 2 * NUM_CHUNKS );
+    chunk_dechunk_22_s32_to_s32( (int32_t*)c_ref, (int32_t*)c0_ref, 2 * NUM_CHUNKS );
 
     /* Step 2: NTT-based multiplication */
     measure_start();
-    int_muladd_mve_chunked_u22( c, a0, b0, a1, b1 );
+    int_muladd_mve_chunked_u22( (int32_t*)c, a0, b0, a1, b1 );
     measure_end();
 
     /* Step 3: Compare results */

--- a/tests/intmulntt/main.c
+++ b/tests/intmulntt/main.c
@@ -111,7 +111,6 @@ void reduce_q_u32( int32_t *src, size_t size, int32_t modulus )
 {
     for( unsigned idx = 0; idx < size; idx++ )
     {
-        int64_t tmp;
         src[idx] = src[idx] % modulus;
         if( src[idx] < 0 )
             src[idx] += modulus;
@@ -369,7 +368,7 @@ int test_intchunkmul()
     }
 
     /* Step 1: Reference product */
-    poly_u22_mul_C( c_tmp, a, b, 0 /* no modulus */ );
+    poly_u22_mul_C( c_tmp, a, b );
     chunk_dechunk_22_64_to_32( c_ref, c_tmp, 2 * NUM_CHUNKS );
 
     /* Step 2: NTT-based multiplication */
@@ -430,9 +429,9 @@ int test_intchunkmulsub()
     }
 
     /* Step 1: Reference product */
-    poly_u22_mul_C( c0_tmp, a0, b0, 0 /* no modulus */ );
+    poly_u22_mul_C( c0_tmp, a0, b0 );
     chunk_dechunk_22_64_to_32( c0_ref, c0_tmp, 2 * NUM_CHUNKS );
-    poly_u22_mul_C( c1_tmp, a1, b1, 0 /* no modulus */ );
+    poly_u22_mul_C( c1_tmp, a1, b1 );
     chunk_dechunk_22_64_to_32( c1_ref, c1_tmp, 2 * NUM_CHUNKS );
 
     sub_s32( c0_ref, c0_ref, c1_ref, 2 * NUM_CHUNKS );
@@ -496,9 +495,9 @@ int test_intchunkmuladd()
     }
 
     /* Step 1: Reference product */
-    poly_u22_mul_C( c0_tmp, a0, b0, 0 /* no modulus */ );
+    poly_u22_mul_C( c0_tmp, a0, b0 );
     chunk_dechunk_22_64_to_32( c0_ref, c0_tmp, 2 * NUM_CHUNKS );
-    poly_u22_mul_C( c1_tmp, a1, b1, 0 /* no modulus */ );
+    poly_u22_mul_C( c1_tmp, a1, b1 );
     chunk_dechunk_22_64_to_32( c1_ref, c1_tmp, 2 * NUM_CHUNKS );
 
     add_s32( c0_ref, c0_ref, c1_ref, 2 * NUM_CHUNKS );
@@ -552,7 +551,7 @@ int test_intpolymul()
     }
 
     /* Step 1: Reference product */
-    poly_u22_mul_C( c_ref, a, b, 0 /* no modulus */ );
+    poly_u22_mul_C( c_ref, a, b );
     /* Step 2: NTT-based multiplication */
     measure_start();
     poly_u22_mul_mve( c, a, b );

--- a/tests/montgomery/main.c
+++ b/tests/montgomery/main.c
@@ -85,7 +85,6 @@ void reduce_q_u16( int16_t *src, size_t size )
 {
     for( unsigned idx = 0; idx < size; idx++ )
     {
-        int32_t tmp;
         src[idx] = src[idx] % mod_q16;
         if( src[idx] < 0 )
             src[idx] += mod_q16;
@@ -341,7 +340,6 @@ static void twisted_mul_deg4_u32_C( int32_t const *src_a,
         int64_t b1  = src_b[ idxb + 2 ];
         int64_t b2  = src_b[ idxb + 1 ];
         int64_t b3  = src_b[ idxb + 0 ];
-        int64_t bt0 = src_b[ idxb + 7 ];
         int64_t bt1 = src_b[ idxb + 6 ];
         int64_t bt2 = src_b[ idxb + 5 ];
         int64_t bt3 = src_b[ idxb + 4 ];
@@ -588,7 +586,6 @@ void reduce_q_u32( int32_t *src, size_t size )
 {
     for( unsigned idx = 0; idx < size; idx++ )
     {
-        int64_t tmp;
         src[idx] = src[idx] % mod_q32;
         if( src[idx] < 0 )
             src[idx] += mod_q32;

--- a/tests/montgomery/main.c
+++ b/tests/montgomery/main.c
@@ -496,38 +496,9 @@ static void cyclic_mul_deg4_u32_add_sub_C( int32_t *dst,
 }
 
 /* Reference C-implementation for multiplication in F_q[X]/(X^4-1). */
-static void cyclic_mul_deg4_u32_arith_rev_C( int32_t *dst,
-                                             size_t size )
-{
-    int32_t * dst_h = dst + size/2;
-    for( unsigned idx = 0; idx <= size/2; idx += 4, dst += 4, dst_h += 4 )
-    {
-        int32_t tmp;
-#define SWAP(a,b) do { tmp = (a); (a) = (b); (b) = tmp; } while( 0 )
-        SWAP(dst[0], dst_h[0]);
-        SWAP(dst[1], dst_h[1]);
-        SWAP(dst[2], dst_h[2]);
-        SWAP(dst[3], dst_h[3]);
-#undef SWAP
-    }
-}
 
-/* Reference C-implementation for multiplication in F_q[X]/(X^4-1). */
-static void cyclic_mul_deg4_u32_split_halves_C( int32_t *dst )
-{
-    int32_t tmp[VECTOR_LENGTH] __attribute__((aligned(16)));
-    int32_t (*tmp_)[4] = (int32_t (*)[4]) tmp;
-    int32_t (*dst_)[4] = (int32_t (*)[4]) dst;
 
-    unsigned blocks = VECTOR_LENGTH/4;
-    for( unsigned idx = 0; idx < blocks/2; idx++ )
-    {
-        memcpy(tmp_ + 0*(blocks/2) + idx, dst_ + 2*idx + 0, 16 );
-        memcpy(tmp_ + 1*(blocks/2) + idx, dst_ + 2*idx + 1, 16 );
-    }
 
-    memcpy( dst, tmp, sizeof( tmp ) );
-}
 
 /* Reference C-implementation for multiplication in F_q[X]/(X^4-1). */
 static void cyclic_mul_deg4_u32_long_C( int32_t const *src_a,
@@ -827,8 +798,8 @@ int test_twisted_cyclic_mul_deg4_u32()
     memset( src_b,   0, sizeof( src_b ) );
     memset( dst_mve, 0, sizeof( dst_mve ) );
 
-    fill_random_u32( src_a, VECTOR_LENGTH );
-    fill_random_u32( src_b, VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_a, VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_b, VECTOR_LENGTH );
 
     reduce_q_u32( src_a, VECTOR_LENGTH );
     reduce_q_u32( src_b, VECTOR_LENGTH );
@@ -852,7 +823,7 @@ int test_twisted_cyclic_mul_deg4_u32()
     reduce_q_u32( dst_mve, VECTOR_LENGTH );
     mul_q_u32( dst_mve, (int64_t) 1 << 32, VECTOR_LENGTH );
 
-    if( compare_buf_u32( dst_C, dst_mve, VECTOR_LENGTH ) != 0 )
+    if( compare_buf_u32( (uint32_t*)dst_C, (uint32_t*)dst_mve, VECTOR_LENGTH ) != 0 )
     {
         debug_print_buf_s32( src_a,   VECTOR_LENGTH, "A" );
         debug_print_buf_s32( src_b,   VECTOR_LENGTH, "B" );
@@ -877,8 +848,8 @@ int test_twisted_cyclic_mul_deg4_u32_expand()
 
     debug_test_start( "Deg-4 basemul preparation" );
 
-    fill_random_u32( src,      VECTOR_LENGTH );
-    fill_random_u32( twiddles, 2*(VECTOR_LENGTH/4) );
+    fill_random_u32( (uint32_t*)src,      VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)twiddles, 2*(VECTOR_LENGTH/4) );
 
     for( unsigned i=0; i < VECTOR_LENGTH/4; i++ )
         twiddles[2*i] = twiddles[2*i] % mod_q32;
@@ -906,7 +877,7 @@ int test_twisted_cyclic_mul_deg4_u32_expand()
     reduce_q_u32( src_expanded_C, 2 * VECTOR_LENGTH );
     reduce_q_u32( src_expanded, 2 * VECTOR_LENGTH );
 
-    if( compare_buf_u32( src_expanded_C, src_expanded, 2*VECTOR_LENGTH ) != 0 )
+    if( compare_buf_u32( (uint32_t*)src_expanded_C, (uint32_t*)src_expanded, 2*VECTOR_LENGTH ) != 0 )
     {
         debug_print_buf_s32( src_expanded_C, 2 * VECTOR_LENGTH, "ref" );
         debug_print_buf_s32( src_expanded,   2 * VECTOR_LENGTH, "mve" );
@@ -938,9 +909,9 @@ int test_twisted_cyclic_mul_deg4_u32_expand_double()
 
     debug_test_start( "Deg-4 basemul preparation, double" );
 
-    fill_random_u32( src,         VECTOR_LENGTH );
-    fill_random_u32( twiddles,    2*(VECTOR_LENGTH/4) );
-    fill_random_u32( twiddle_fix, 1 );
+    fill_random_u32( (uint32_t*)src,         VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)twiddles,    2*(VECTOR_LENGTH/4) );
+    fill_random_u32( (uint32_t*)twiddle_fix, 1 );
     twiddle_fix[0] = twiddle_fix[0] % mod_q32;
 
     for( unsigned i=0; i < VECTOR_LENGTH/4; i++ )
@@ -972,7 +943,7 @@ int test_twisted_cyclic_mul_deg4_u32_expand_double()
     reduce_q_u32( src_expanded_C, 2 * VECTOR_LENGTH );
     reduce_q_u32( src_expanded, 2 * VECTOR_LENGTH );
 
-    if( compare_buf_u32( src_expanded_C, src_expanded, 2*VECTOR_LENGTH ) != 0 )
+    if( compare_buf_u32( (uint32_t*)src_expanded_C, (uint32_t*)src_expanded, 2*VECTOR_LENGTH ) != 0 )
     {
         debug_print_buf_s32( src_expanded_C, 2 * VECTOR_LENGTH, "ref" );
         debug_print_buf_s32( src_expanded,   2 * VECTOR_LENGTH, "mve" );
@@ -1016,8 +987,8 @@ int test_twisted_cyclic_mul_deg4_u32_add_sub()
     memset( src_b,   0, sizeof( src_b ) );
     memset( dst_mve, 0, sizeof( dst_mve ) );
 
-    fill_random_u32( src_a, VECTOR_LENGTH );
-    fill_random_u32( src_b, VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_a, VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_b, VECTOR_LENGTH );
 
     reduce_q_u32( src_a, VECTOR_LENGTH );
     reduce_q_u32( src_b, VECTOR_LENGTH );
@@ -1043,7 +1014,7 @@ int test_twisted_cyclic_mul_deg4_u32_add_sub()
     reduce_q_u32( dst_mve, VECTOR_LENGTH );
     mul_q_u32( dst_mve, (int64_t) 1 << 32, VECTOR_LENGTH );
 
-    if( compare_buf_u32( dst_C, dst_mve, VECTOR_LENGTH ) != 0 )
+    if( compare_buf_u32( (uint32_t*)dst_C, (uint32_t*)dst_mve, VECTOR_LENGTH ) != 0 )
     {
         for( unsigned idx=0; idx < VECTOR_LENGTH; idx++ )
             if( dst_C[idx] != dst_mve[idx] )
@@ -1084,8 +1055,8 @@ int test_twisted_cyclic_mul_deg4_u32_add_sub_rev()
     memset( src_b_expanded,   0, sizeof( src_b_expanded ) );
     memset( dst_mve, 0, sizeof( dst_mve ) );
 
-    fill_random_u32( src_a, VECTOR_LENGTH );
-    fill_random_u32( src_b_expanded, 2 * VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_a, VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_b_expanded, 2 * VECTOR_LENGTH );
 
     reduce_q_u32( src_a, VECTOR_LENGTH );
     reduce_q_u32( src_b_expanded, 2 * VECTOR_LENGTH );
@@ -1105,7 +1076,7 @@ int test_twisted_cyclic_mul_deg4_u32_add_sub_rev()
     reduce_q_u32( dst_mve, VECTOR_LENGTH );
     mul_q_u32( dst_mve, (int64_t) 1 << 32, VECTOR_LENGTH );
 
-    if( compare_buf_u32( dst_C, dst_mve, VECTOR_LENGTH ) != 0 )
+    if( compare_buf_u32( (uint32_t*)dst_C, (uint32_t*)dst_mve, VECTOR_LENGTH ) != 0 )
     {
         for( unsigned idx=0; idx < VECTOR_LENGTH; idx++ )
             if( dst_C[idx] != dst_mve[idx] )
@@ -1181,8 +1152,8 @@ int test_twisted_cyclic_mul_deg4_u32_long()
     memset( src_b,   0, sizeof( src_b ) );
     memset( dst_mve, 0, sizeof( dst_mve ) );
 
-    fill_random_u32( src_a, VECTOR_LENGTH );
-    fill_random_u32( src_b, VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_a, VECTOR_LENGTH );
+    fill_random_u32( (uint32_t*)src_b, VECTOR_LENGTH );
 
     reduce_q_u32( src_a, VECTOR_LENGTH );
     reduce_q_u32( src_b, VECTOR_LENGTH );
@@ -1202,7 +1173,7 @@ int test_twisted_cyclic_mul_deg4_u32_long()
     twisted_cyclic_mul_deg4_u32_long_mve_v1( src_a, src_b_expanded, dst_mve );
     measure_end();
 
-    if( compare_buf_u64( dst_C, dst_mve, VECTOR_LENGTH ) != 0 )
+    if( compare_buf_u64( (uint64_t*)dst_C, (uint64_t*)dst_mve, VECTOR_LENGTH ) != 0 )
     {
         debug_print_buf_s32( src_a,   VECTOR_LENGTH, "A" );
         debug_print_buf_s32( src_b,   VECTOR_LENGTH, "B" );
@@ -1277,7 +1248,6 @@ int test_montgomery_u16_round()
     uint16_t src_b[2];
 
     int16_t dst    [SIZE];
-    int16_t dst_mon[SIZE];
     int16_t dst_C  [SIZE];
     int16_t dst_mve[SIZE];
 
@@ -1312,10 +1282,10 @@ int test_montgomery_u16_round()
     src_b[1] = montgomery_multiplier * mod_q16_inv_u16;
 
     /* Step 1: MVE based Montgomery multiplication */
-    montgomery_u16_round_mve( src_a, src_b, dst_mve );
+    montgomery_u16_round_mve( src_a, (int16_t*)src_b, dst_mve );
 
     /* Step 2: Reference C Montgomery multiplication */
-    montgomery_u16_C( src_a, src_b, dst_C );
+    montgomery_u16_C( src_a, (int16_t*)src_b, dst_C );
 
     /* Step 3: Reference C multiplication */
     mult_u16_C( src_a, real_multiplier, dst );
@@ -1349,8 +1319,8 @@ int test_montgomery_u16_round()
 }
 #endif /* TEST_CORE_ONLY */
 
-void mult_u32_C( int32_t const *src_a,
-                 int32_t const *src_b,
+void mult_u32_C( int32_t *src_a,
+                 int32_t *src_b,
                  int32_t *dst,
                  size_t size )
 {
@@ -1451,7 +1421,6 @@ int test_montgomery_pt_u32_round()
     int32_t * const src_b = src_b_ + 2;
 
     int32_t dst    [SIZE];
-    int32_t dst_mon[SIZE];
     int32_t dst_C  [SIZE];
     int32_t dst_mve[SIZE];
 
@@ -1528,7 +1497,6 @@ int test_montgomery_pt_u32()
     int32_t src_b[SIZE];
 
     int32_t dst    [SIZE];
-    int32_t dst_mon[SIZE];
     int32_t dst_C  [SIZE];
     int32_t dst_mve[SIZE];
 
@@ -2044,7 +2012,6 @@ int test_montgomery_pt_u16_round()
     int16_t * const src_b = src_b_ + 2;
 
     int16_t dst    [SIZE];
-    int16_t dst_mon[SIZE];
     int16_t dst_C  [SIZE];
     int16_t dst_mve[SIZE];
 

--- a/tests/ntt-1024/main.c
+++ b/tests/ntt-1024/main.c
@@ -66,6 +66,7 @@ void ntt_u32_mve_rev4(uint32_t *);
 
 #if !defined(NTT_INCOMPLETE)
 #define ntt_u32_mve ntt_1024_u32_33564673_286215
+#define NTT_U32_MVE_CAST(x) (x)  /* Complete version takes int32_t* */
 #else
 #define ntt_u32_mve                  ntt_1024_u32_33564673_286215_incomplete
 #define ntt_u32_mve_rev4             ntt_1024_u32_33564673_286215_incomplete_rev4
@@ -74,6 +75,7 @@ void ntt_u32_mve_rev4(uint32_t *);
 #define ntt_u32_mve_bitrev_skipfirst ntt_1024_u32_33564673_286215_incomplete_bitrev_skipfirst
 #define ntt_u32_mve_double_rev4      ntt_1024_u32_33564673_286215_incomplete_double_rev4
 #define ntt_u32_mve_double           ntt_1024_u32_33564673_286215_incomplete_double
+#define NTT_U32_MVE_CAST(x) ((uint32_t*)(x))  /* Incomplete version takes uint32_t* */
 #endif
 
 /* Cyclic signed schoolbook multiplications */
@@ -344,7 +346,7 @@ int run_test_ntt()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_u32_mve( src );
+    ntt_u32_mve( NTT_U32_MVE_CAST(src) );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -391,7 +393,7 @@ int run_test_ntt_rev4()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_u32_mve_rev4( src );
+    ntt_u32_mve_rev4( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -442,7 +444,7 @@ int run_test_ntt_bitrev()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_u32_mve_bitrev( src );
+    ntt_u32_mve_bitrev( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -499,8 +501,8 @@ int run_test_ntt_fwd_inv_bitrev()
 
     /* Step 2: MVE-based NTT */
 
-    ntt_u32_mve( src );
-    ntt_u32_mve_bitrev( src );
+    ntt_u32_mve( NTT_U32_MVE_CAST(src) );
+    ntt_u32_mve_bitrev( (uint32_t*)src );
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
 
@@ -568,7 +570,7 @@ int run_test_ntt_skipfirst()
     // First layer is skipped by MVE implementation
     ntt_u32_first_layer( src );
     measure_start();
-    ntt_u32_mve_skipfirst( src );
+    ntt_u32_mve_skipfirst( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -610,7 +612,7 @@ int run_test_ntt_bitrev_skipfirst()
     // First layer is skipped by MVE implementation
     ntt_u32_first_layer_bitrev( src );
     measure_start();
-    ntt_u32_mve_bitrev_skipfirst( src );
+    ntt_u32_mve_bitrev_skipfirst( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -656,6 +658,7 @@ int run_test_ntt_bitrev_skipfirst()
 #if !defined(TEST_CORE_ONLY)
 int32_t ntt_root_for_block( int layer, int block )
 {
+    (void)layer; // Suppress unused parameter warning
     int log;
     int32_t root;
     log = bit_reverse(/*(1 << layer) + */ block, NTT_LAYERS-1);
@@ -719,7 +722,7 @@ int run_test_ntt_incomplete_double()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_u32_mve_double( src, dst_mve );
+    ntt_u32_mve_double( (uint32_t*)src, (uint32_t*)dst_mve );
     measure_end();
 
     mod_reduce_buf_s32( dst_C,   2 * NTT_SIZE, modulus );
@@ -805,7 +808,7 @@ int run_test_ntt_incomplete_double_rev4()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_u32_mve_double_rev4( src, dst_mve );
+    ntt_u32_mve_double_rev4( (uint32_t*)src, (uint32_t*)dst_mve );
     measure_end();
 
     mod_reduce_buf_s32( dst_C,   2 * NTT_SIZE, modulus );
@@ -878,10 +881,10 @@ void poly_mul_1024( int32_t *dst, int32_t *srcA, int32_t *srcB )
     };
 
     int32_t tmpB[2*NTT_SIZE];
-    ntt_u32_mve_rev4( srcA );
-    ntt_u32_mve_double_rev4( srcB, tmpB );
-    twisted_cyclic_mul_deg4_u32_add_sub_rev_mve( srcA, tmpB, dst, params );
-    ntt_u32_mve_bitrev_skipfirst( dst );
+    ntt_u32_mve_rev4( (uint32_t*)srcA );
+    ntt_u32_mve_double_rev4( (uint32_t*)srcB, (uint32_t*)tmpB );
+    twisted_cyclic_mul_deg4_u32_add_sub_rev_mve( (uint32_t*)srcA, (uint32_t*)tmpB, (uint32_t*)dst, (uint32_t*)params );
+    ntt_u32_mve_bitrev_skipfirst( (uint32_t*)dst );
 }
 
 int run_test_poly_mul()

--- a/tests/ntt-192/main.c
+++ b/tests/ntt-192/main.c
@@ -406,7 +406,6 @@ void poly_mul_192( int32_t *dst, int32_t *srcA, int32_t *srcB )
 int run_test_poly_mul()
 {
     int32_t A[NTT_SIZE], B[NTT_SIZE], C[NTT_SIZE], C_ref[NTT_SIZE];
-    int32_t pow_2k_inv;
     debug_test_start( "Polynomial multiplication in F_q[X]/(X^192-1)" );
 
     fill_random_u32( (uint32_t*) A, NTT_SIZE );

--- a/tests/ntt-384/main.c
+++ b/tests/ntt-384/main.c
@@ -266,6 +266,7 @@ int check_good_permutation()
     }
 
     debug_test_ok();
+    return( 0 );
 }
 
 #if !defined(TEST_CORE_ONLY)
@@ -290,7 +291,7 @@ int run_test_ntt_good()
     /* Step 2: MVE-based NTT */
 
     measure_start();
-    ntt_u32_mve_good( src );
+    ntt_u32_mve_good( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -373,7 +374,7 @@ int run_test_ntt_good_oop()
     /* Step 2: MVE-based NTT */
 
     measure_start();
-    ntt_u32_mve_good_oop( src, dst );
+    ntt_u32_mve_good_oop( (uint32_t*)src, (uint32_t*)dst );
     measure_end();
 
     mod_reduce_buf_s32( dst, NTT_SIZE, modulus );
@@ -414,7 +415,7 @@ int run_test_ntt_good_oop_half_input()
     /* Step 2: MVE-based NTT */
 
     measure_start();
-    ntt_u32_mve_good_oop_half_input( src, dst );
+    ntt_u32_mve_good_oop_half_input( (uint32_t*)src, (uint32_t*)dst );
     measure_end();
 
     mod_reduce_buf_s32( dst, NTT_SIZE, modulus );
@@ -447,9 +448,9 @@ int run_test_ntt_good_bitrev()
 
     /* Step 2: MVE-based NTT */
 
-    ntt_u32_mve_good( src );
+    ntt_u32_mve_good( (uint32_t*)src );
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
-    ntt_u32_mve_good_bitrev( src );
+    ntt_u32_mve_good_bitrev( (uint32_t*)src );
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
 
     pow_2k_inv = mod_pow_s32( (modulus+1)/2, 5, modulus );
@@ -510,21 +511,20 @@ void poly_mul_384( int32_t *dst, int32_t *srcA, int32_t *srcB )
     };
 
     int32_t tmpB[2*NTT_SIZE];
-    ntt_u32_mve_good( srcA );
-    ntt_u32_mve_good( srcB );
+    ntt_u32_mve_good( (uint32_t*)srcA );
+    ntt_u32_mve_good( (uint32_t*)srcB );
     twisted_cyclic_mul_deg4_u32_mve_expand_double( tmpB, srcB,
                                                    ntt_u32_mve_good_twiddles,
                                                    ntt_u32_mve_good_scale,
                                                    NTT_PRIME );
     twisted_cyclic_mul_deg4_u32_mve_alt( srcA, tmpB, dst, params );
-    ntt_u32_mve_good_bitrev( dst );
+    ntt_u32_mve_good_bitrev( (uint32_t*)dst );
 }
 
 int run_test_poly_mul()
 {
     srand(time(NULL));
     int32_t A[NTT_SIZE], B[NTT_SIZE], C[NTT_SIZE], C_ref[NTT_SIZE];
-    int32_t pow_2k_inv;
     debug_test_start( "Polynomial multiplication in F_q[X]/(X^384-1)" );
 
     fill_random_u32( (uint32_t*) A, NTT_SIZE );

--- a/tests/ntt-512/main.c
+++ b/tests/ntt-512/main.c
@@ -263,7 +263,7 @@ int run_test_ntt()
     // First layer is skipped by MVE implementation
     ntt_u32_first_layer( src );
     measure_start();
-    ntt_u32_mve( src );
+    ntt_u32_mve( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -284,7 +284,7 @@ int run_test_ntt()
 {
     int32_t src[NTT_SIZE]      __attribute__((aligned(16)));
     measure_start();
-    ntt_u32_mve( src );
+    ntt_u32_mve( (uint32_t*)src );
     measure_end();
     return( 0 );
 }

--- a/tests/ntt-768/main.c
+++ b/tests/ntt-768/main.c
@@ -331,6 +331,7 @@ int check_good_permutation()
     }
 
     debug_test_ok();
+    return( 0 );
 }
 
 int check_ntt_involutive()
@@ -396,7 +397,7 @@ int run_test_ntt_fwd_inv_bitrev()
     /* Step 2: MVE-based NTT */
 
     ntt_u32_mve( src );
-    ntt_u32_mve_bitrev( src );
+    ntt_u32_mve_bitrev( (uint32_t*)src );
 
     ntt_u32_permute_bitrev_inv( src );
     ntt_u32_permute_bitrev_inv( src );
@@ -501,7 +502,7 @@ int run_test_ntt_good()
     /* Step 2: MVE-based NTT */
 
     measure_start();
-    ntt_u32_mve_good( src );
+    ntt_u32_mve_good( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -546,9 +547,9 @@ int run_test_ntt_good_bitrev()
 
     /* Step 2: MVE-based NTT */
 
-    ntt_u32_mve_good( src );
+    ntt_u32_mve_good( (uint32_t*)src );
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
-    ntt_u32_mve_good_bitrev( src );
+    ntt_u32_mve_good_bitrev( (uint32_t*)src );
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
 
     pow_2k_inv = mod_pow_s32( (modulus+1)/2, 6, modulus );
@@ -634,7 +635,7 @@ int run_test_ntt_bitrev()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_u32_mve_bitrev( src );
+    ntt_u32_mve_bitrev( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -681,7 +682,7 @@ int run_test_ntt_rev4()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_u32_mve_rev4( src );
+    ntt_u32_mve_rev4( (uint32_t*)src );
     measure_end();
 
     mod_reduce_buf_s32( src, NTT_SIZE, modulus );
@@ -726,20 +727,19 @@ void poly_mul_768( int32_t *dst, int32_t *srcA, int32_t *srcB )
     };
 
     int32_t tmpB[2*NTT_SIZE];
-    ntt_u32_mve_good( srcA );
-    ntt_u32_mve_good( srcB );
-    twisted_cyclic_mul_deg4_u32_mve_expand_double( tmpB, srcB,
-                                                   ntt_u32_mve_good_twiddles,
-                                                   ntt_u32_mve_good_scale,
+    ntt_u32_mve_good( (uint32_t*)srcA );
+    ntt_u32_mve_good( (uint32_t*)srcB );
+    twisted_cyclic_mul_deg4_u32_mve_expand_double( (uint32_t*)tmpB, (uint32_t*)srcB,
+                                                   (uint32_t*)ntt_u32_mve_good_twiddles,
+                                                   (uint32_t*)ntt_u32_mve_good_scale,
                                                    modulus );
-    twisted_cyclic_mul_deg4_u32_mve_alt( srcA, tmpB, dst, params );
-    ntt_u32_mve_good_bitrev( dst );
+    twisted_cyclic_mul_deg4_u32_mve_alt( (uint32_t*)srcA, (uint32_t*)tmpB, (uint32_t*)dst, (uint32_t*)params );
+    ntt_u32_mve_good_bitrev( (uint32_t*)dst );
 }
 
 int run_test_poly_mul()
 {
     int32_t A[NTT_SIZE], B[NTT_SIZE], C[NTT_SIZE], C_ref[NTT_SIZE];
-    int32_t pow_2k_inv;
     debug_test_start( "Polynomial multiplication in F_q[X]/(X^768-1)" );
 
     fill_random_u32( (uint32_t*) A, NTT_SIZE );

--- a/tests/ntt-n256/main.c
+++ b/tests/ntt-n256/main.c
@@ -354,7 +354,7 @@ int run_test_ntt_incomplete_double()
 
     /* Step 2: MVE-based NTT */
     measure_start();
-    ntt_incomplete_double_u32_mve( src, dst_mve );
+    ntt_incomplete_double_u32_mve( (uint32_t*)src, (uint32_t*)dst_mve );
     measure_end();
 
     mod_reduce_buf_s32( dst_C,   2 * NTT_SIZE, modulus );
@@ -394,8 +394,6 @@ int run_test_ntt_fwd_inv()
     debug_test_start( "NTT forward-inverse u32" );
     int32_t src[NTT_SIZE]      __attribute__((aligned(16)));
     int32_t src_copy[NTT_SIZE] __attribute__((aligned(16)));
-
-    int32_t pow_2k_inv;
 
     /* Setup input */
     fill_random_u32( (uint32_t*) src, NTT_SIZE );

--- a/tests/permute/main.c
+++ b/tests/permute/main.c
@@ -52,7 +52,7 @@ int run_permute_test_u ## bits ()                               \
     unsigned entries = BUFSZ_BYTES / BITS_TO_BYTES(bits);       \
     int fail = 0;                                               \
     int multiples;                                              \
-    int values;                                                 \
+    unsigned values;                                                 \
                                                                 \
     debug_test_start( "Test: " #bits "-bit permutation");       \
                                                                 \
@@ -80,7 +80,7 @@ int run_permute_test_u ## bits ()                               \
     for( i = 0; i < values; i++ )                               \
     {                                                           \
         int num_found = 0;                                      \
-        for( j = 0; j < entries; j++ )                          \
+        for( j = 0; j < (unsigned)entries; j++ )                          \
         {                                                       \
             if( dst[j] == i )                                   \
                 num_found++;                                    \

--- a/tests/poly/main.c
+++ b/tests/poly/main.c
@@ -335,7 +335,6 @@ void mat_vec_mul_u16_C( uint16_t A  [MAT_DIM][MAT_DIM][POLY_DEG],
                         uint16_t w  [MAT_DIM][POLY_DEG],
                         uint16_t dst[MAT_DIM][POLY_DEG] )
 {
-    uint16_t tmp[POLY_DEG] = { 0 };
     for( unsigned i = 0; i < MAT_DIM; i++ )
         vec_vec_dot_u16_C( A[i], w, dst[i] );
 }
@@ -400,6 +399,7 @@ int test_mat_vec_mul_tc_kara(void)
     defined(TEST_POLY_MUL_NTT_INCOMPLETE)
 
 #define POLY_DEG     256
+#undef EVAL_DEG
 #define EVAL_DEG     256
 
 void ntt_u32_33556993_28678040(int32_t *src);

--- a/tests/toom/main.c
+++ b/tests/toom/main.c
@@ -875,6 +875,7 @@ static void poly_u16_toom4_fwd_dual_bottom_C( uint16_t *poly )
 
 /* Compute the Toom3 evaluation step in-place, evaluating
  * at the points 0, -1, +1, -2, infty in this order. */
+/*
 static void poly_u16_toom3_fwd_C( uint16_t *poly )
 {
     unsigned limb_dim = DIMENSION / 3;
@@ -898,6 +899,7 @@ static void poly_u16_toom3_fwd_C( uint16_t *poly )
         eval[4][idx] = (uint16_t)(               val_c );
     }
 }
+*/
 
 /*
  * Test case generation
@@ -1789,8 +1791,6 @@ static void multiply_by_eval_of_1_toom4_dual_top( uint16_t *poly_a )
 #if defined(TEST_TOOM4_FWD_INV_DUAL_TOP)
 int unfold(test_toom4_fwd_inv_dual_top)()
 {
-    uint16_t * const a_shift = a + 3*DIMENSION_DIV4;
-    uint16_t * const b_shift = b + 3*DIMENSION_DIV4;
     debug_test_start( TEST_STRING_TOOM4_FWD_INV_DUAL_TOP_START );
 
     generate_sample();

--- a/tests/toom/main.c
+++ b/tests/toom/main.c
@@ -515,19 +515,19 @@ static void poly_u16_toom4_fwd_C( uint16_t *poly )
 
     for( idx = 0; idx < limb_dim; idx++ )
     {
-        uint16_t a,b,c,d;
-        a = limb[0][idx];
-        b = limb[1][idx];
-        c = limb[2][idx];
-        d = limb[3][idx];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = limb[0][idx];
+        val_b = limb[1][idx];
+        val_c = limb[2][idx];
+        val_d = limb[3][idx];
 
-        eval[0][idx] = (uint16_t)(   a );
-        eval[1][idx] = (uint16_t)( 8*a - 4*b + 2*c -   d );
-        eval[2][idx] = (uint16_t)( 8*a + 4*b + 2*c +   d );
-        eval[3][idx] = (uint16_t)(   a -   b +   c -   d );
-        eval[4][idx] = (uint16_t)(   a +   b +   c +   d );
-        eval[5][idx] = (uint16_t)(   a + 2*b + 4*c + 8*d );
-        eval[6][idx] = (uint16_t)(                     d );
+        eval[0][idx] = (uint16_t)(   val_a );
+        eval[1][idx] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );
+        eval[2][idx] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );
+        eval[3][idx] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );
+        eval[4][idx] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );
+        eval[5][idx] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );
+        eval[6][idx] = (uint16_t)(                     val_d );
     }
 }
 
@@ -543,19 +543,19 @@ static void poly_u16_toom4_fwd_oop_C( uint16_t *src, uint16_t *dst )
 
     for( idx = 0; idx < limb_dim; idx++ )
     {
-        uint16_t a,b,c,d;
-        a = limb[0][idx];
-        b = limb[1][idx];
-        c = limb[2][idx];
-        d = limb[3][idx];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = limb[0][idx];
+        val_b = limb[1][idx];
+        val_c = limb[2][idx];
+        val_d = limb[3][idx];
 
-        eval[0][idx] = (uint16_t)(   a );
-        eval[1][idx] = (uint16_t)( 8*a - 4*b + 2*c -   d );
-        eval[2][idx] = (uint16_t)( 8*a + 4*b + 2*c +   d );
-        eval[3][idx] = (uint16_t)(   a -   b +   c -   d );
-        eval[4][idx] = (uint16_t)(   a +   b +   c +   d );
-        eval[5][idx] = (uint16_t)(   a + 2*b + 4*c + 8*d );
-        eval[6][idx] = (uint16_t)(                     d );
+        eval[0][idx] = (uint16_t)(   val_a );
+        eval[1][idx] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );
+        eval[2][idx] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );
+        eval[3][idx] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );
+        eval[4][idx] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );
+        eval[5][idx] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );
+        eval[6][idx] = (uint16_t)(                     val_d );
     }
 }
 
@@ -571,19 +571,19 @@ static void poly_u16_toom4_fwd_karatsuba_x1_oop_C( uint16_t *src, uint16_t *dst 
 
     for( idx = 0; idx < limb_dim; idx++ )
     {
-        uint16_t a,b,c,d;
-        a = limb[0][idx];
-        b = limb[1][idx];
-        c = limb[2][idx];
-        d = limb[3][idx];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = limb[0][idx];
+        val_b = limb[1][idx];
+        val_c = limb[2][idx];
+        val_d = limb[3][idx];
 
-        dst[0 * padded_limb_dim + idx] = (uint16_t)(   a                   );   /* 0     */
-        dst[1 * padded_limb_dim + idx] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-        dst[2 * padded_limb_dim + idx] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-        dst[3 * padded_limb_dim + idx] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-        dst[4 * padded_limb_dim + idx] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-        dst[5 * padded_limb_dim + idx] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-        dst[6 * padded_limb_dim + idx] = (uint16_t)(                     d );   /* infty */
+        dst[0 * padded_limb_dim + idx] = (uint16_t)(   val_a                   );   /* 0     */
+        dst[1 * padded_limb_dim + idx] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+        dst[2 * padded_limb_dim + idx] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+        dst[3 * padded_limb_dim + idx] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+        dst[4 * padded_limb_dim + idx] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+        dst[5 * padded_limb_dim + idx] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+        dst[6 * padded_limb_dim + idx] = (uint16_t)(                     val_d );   /* infty */
     }
 }
 
@@ -600,36 +600,36 @@ static void poly_u16_toom4_fwd_karatsuba_x2_oop_C( uint16_t *src, uint16_t *dst 
 
     for( idx = 0; idx < limb_dim / 2; idx++ )
     {
-        uint16_t a,b,c,d;
-        a = limb[0][idx];
-        b = limb[1][idx];
-        c = limb[2][idx];
-        d = limb[3][idx];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = limb[0][idx];
+        val_b = limb[1][idx];
+        val_c = limb[2][idx];
+        val_d = limb[3][idx];
 
-        dst[0 * padded_limb_dim + idx] = (uint16_t)(   a                   );   /* 0     */
-        dst[1 * padded_limb_dim + idx] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-        dst[2 * padded_limb_dim + idx] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-        dst[3 * padded_limb_dim + idx] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-        dst[4 * padded_limb_dim + idx] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-        dst[5 * padded_limb_dim + idx] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-        dst[6 * padded_limb_dim + idx] = (uint16_t)(                     d );   /* infty */
+        dst[0 * padded_limb_dim + idx] = (uint16_t)(   val_a                   );   /* 0     */
+        dst[1 * padded_limb_dim + idx] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+        dst[2 * padded_limb_dim + idx] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+        dst[3 * padded_limb_dim + idx] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+        dst[4 * padded_limb_dim + idx] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+        dst[5 * padded_limb_dim + idx] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+        dst[6 * padded_limb_dim + idx] = (uint16_t)(                     val_d );   /* infty */
     }
 
     for( idx = limb_dim/2; idx < limb_dim; idx++ )
     {
-        uint16_t a,b,c,d;
-        a = limb[0][idx];
-        b = limb[1][idx];
-        c = limb[2][idx];
-        d = limb[3][idx];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = limb[0][idx];
+        val_b = limb[1][idx];
+        val_c = limb[2][idx];
+        val_d = limb[3][idx];
 
-        dst[0 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   a                   );   /* 0     */
-        dst[1 * padded_limb_dim + idx + limb_shift] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-        dst[2 * padded_limb_dim + idx + limb_shift] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-        dst[3 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-        dst[4 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-        dst[5 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-        dst[6 * padded_limb_dim + idx + limb_shift] = (uint16_t)(                     d );   /* infty */
+        dst[0 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   val_a                   );   /* 0     */
+        dst[1 * padded_limb_dim + idx + limb_shift] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+        dst[2 * padded_limb_dim + idx + limb_shift] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+        dst[3 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+        dst[4 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+        dst[5 * padded_limb_dim + idx + limb_shift] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+        dst[6 * padded_limb_dim + idx + limb_shift] = (uint16_t)(                     val_d );   /* infty */
     }
 }
 
@@ -652,19 +652,19 @@ static void poly_u16_toom4_fwd_dual_top_C( uint16_t *src, uint16_t *dst )
         for( k=0; k<8; k++ )
         {
             uint16_t tmp_eval[7];
-            uint16_t a,b,c,d;
-            a = tmp[ 4*(8*idx + k) + 0 ];
-            b = tmp[ 4*(8*idx + k) + 1 ];
-            c = tmp[ 4*(8*idx + k) + 2 ];
-            d = tmp[ 4*(8*idx + k) + 3 ];
+            uint16_t val_a,val_b,val_c,val_d;
+            val_a = tmp[ 4*(8*idx + k) + 0 ];
+            val_b = tmp[ 4*(8*idx + k) + 1 ];
+            val_c = tmp[ 4*(8*idx + k) + 2 ];
+            val_d = tmp[ 4*(8*idx + k) + 3 ];
 
-            tmp_eval[0] = (uint16_t)(   a                   );   /* 0     */
-            tmp_eval[1] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-            tmp_eval[2] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-            tmp_eval[3] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-            tmp_eval[4] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-            tmp_eval[5] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-            tmp_eval[6] = (uint16_t)(                     d );   /* infty */
+            tmp_eval[0] = (uint16_t)(   val_a                   );   /* 0     */
+            tmp_eval[1] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+            tmp_eval[2] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+            tmp_eval[3] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+            tmp_eval[4] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+            tmp_eval[5] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+            tmp_eval[6] = (uint16_t)(                     val_d );   /* infty */
 
             dst[idx * 4 * 8 + 8*0 + k] = tmp_eval[0];
             dst[idx * 4 * 8 + 8*1 + k] = tmp_eval[1];
@@ -693,19 +693,19 @@ static void poly_u16_toom4_fwd_dual_packed_limbs_oop_C( uint16_t *src, uint16_t 
     for( idx = 0; idx < limb_dim; idx++ )
     {
         uint16_t tmp_eval[7];
-        uint16_t a,b,c,d;
-        a = tmp[ 4*idx + 0 ];
-        b = tmp[ 4*idx + 1 ];
-        c = tmp[ 4*idx + 2 ];
-        d = tmp[ 4*idx + 3 ];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = tmp[ 4*idx + 0 ];
+        val_b = tmp[ 4*idx + 1 ];
+        val_c = tmp[ 4*idx + 2 ];
+        val_d = tmp[ 4*idx + 3 ];
 
-        tmp_eval[0] = (uint16_t)(   a                   );   /* 0     */
-        tmp_eval[1] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-        tmp_eval[2] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-        tmp_eval[3] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-        tmp_eval[4] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-        tmp_eval[5] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-        tmp_eval[6] = (uint16_t)(                     d );   /* infty */
+        tmp_eval[0] = (uint16_t)(   val_a                   );   /* 0     */
+        tmp_eval[1] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+        tmp_eval[2] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+        tmp_eval[3] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+        tmp_eval[4] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+        tmp_eval[5] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+        tmp_eval[6] = (uint16_t)(                     val_d );   /* infty */
 
         dst[0 * limb_dim + idx] = tmp_eval[0];
         dst[1 * limb_dim + idx] = tmp_eval[1];
@@ -733,19 +733,19 @@ static void poly_u16_toom4_fwd_dual_packed_limbs_karatsuba_x1_oop_C( uint16_t *s
     for( idx = 0; idx < limb_dim; idx++ )
     {
         uint16_t tmp_eval[7];
-        uint16_t a,b,c,d;
-        a = tmp[ 4*idx + 0 ];
-        b = tmp[ 4*idx + 1 ];
-        c = tmp[ 4*idx + 2 ];
-        d = tmp[ 4*idx + 3 ];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = tmp[ 4*idx + 0 ];
+        val_b = tmp[ 4*idx + 1 ];
+        val_c = tmp[ 4*idx + 2 ];
+        val_d = tmp[ 4*idx + 3 ];
 
-        tmp_eval[0] = (uint16_t)(   a                   );   /* 0     */
-        tmp_eval[1] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-        tmp_eval[2] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-        tmp_eval[3] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-        tmp_eval[4] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-        tmp_eval[5] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-        tmp_eval[6] = (uint16_t)(                     d );   /* infty */
+        tmp_eval[0] = (uint16_t)(   val_a                   );   /* 0     */
+        tmp_eval[1] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+        tmp_eval[2] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+        tmp_eval[3] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+        tmp_eval[4] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+        tmp_eval[5] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+        tmp_eval[6] = (uint16_t)(                     val_d );   /* infty */
 
         dst[0 * padded_limb_dim + idx] = tmp_eval[0];
         dst[1 * padded_limb_dim + idx] = tmp_eval[1];
@@ -774,19 +774,19 @@ static void poly_u16_toom4_fwd_dual_packed_limbs_karatsuba_x2_oop_C( uint16_t *s
     for( idx = 0; idx < limb_dim / 2; idx++ )
     {
         uint16_t tmp_eval[7];
-        uint16_t a,b,c,d;
-        a = tmp[ 4*idx + 0 ];
-        b = tmp[ 4*idx + 1 ];
-        c = tmp[ 4*idx + 2 ];
-        d = tmp[ 4*idx + 3 ];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = tmp[ 4*idx + 0 ];
+        val_b = tmp[ 4*idx + 1 ];
+        val_c = tmp[ 4*idx + 2 ];
+        val_d = tmp[ 4*idx + 3 ];
 
-        tmp_eval[0] = (uint16_t)(   a                   );   /* 0     */
-        tmp_eval[1] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-        tmp_eval[2] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-        tmp_eval[3] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-        tmp_eval[4] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-        tmp_eval[5] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-        tmp_eval[6] = (uint16_t)(                     d );   /* infty */
+        tmp_eval[0] = (uint16_t)(   val_a                   );   /* 0     */
+        tmp_eval[1] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+        tmp_eval[2] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+        tmp_eval[3] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+        tmp_eval[4] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+        tmp_eval[5] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+        tmp_eval[6] = (uint16_t)(                     val_d );   /* infty */
 
         dst[0 * padded_limb_dim + idx] = tmp_eval[0];
         dst[1 * padded_limb_dim + idx] = tmp_eval[1];
@@ -800,19 +800,19 @@ static void poly_u16_toom4_fwd_dual_packed_limbs_karatsuba_x2_oop_C( uint16_t *s
     for( idx = limb_dim / 2; idx < limb_dim; idx++ )
     {
         uint16_t tmp_eval[7];
-        uint16_t a,b,c,d;
-        a = tmp[ 4*idx + 0 ];
-        b = tmp[ 4*idx + 1 ];
-        c = tmp[ 4*idx + 2 ];
-        d = tmp[ 4*idx + 3 ];
+        uint16_t val_a,val_b,val_c,val_d;
+        val_a = tmp[ 4*idx + 0 ];
+        val_b = tmp[ 4*idx + 1 ];
+        val_c = tmp[ 4*idx + 2 ];
+        val_d = tmp[ 4*idx + 3 ];
 
-        tmp_eval[0] = (uint16_t)(   a                   );   /* 0     */
-        tmp_eval[1] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-        tmp_eval[2] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-        tmp_eval[3] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-        tmp_eval[4] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-        tmp_eval[5] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-        tmp_eval[6] = (uint16_t)(                     d );   /* infty */
+        tmp_eval[0] = (uint16_t)(   val_a                   );   /* 0     */
+        tmp_eval[1] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+        tmp_eval[2] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+        tmp_eval[3] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+        tmp_eval[4] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+        tmp_eval[5] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+        tmp_eval[6] = (uint16_t)(                     val_d );   /* infty */
 
         dst[0 * padded_limb_dim + idx + limb_shift] = tmp_eval[0];
         dst[1 * padded_limb_dim + idx + limb_shift] = tmp_eval[1];
@@ -846,19 +846,19 @@ static void poly_u16_toom4_fwd_dual_bottom_C( uint16_t *poly )
         for( k=0; k<8; k++ )
         {
             uint16_t tmp_eval[7];
-            uint16_t a,b,c,d;
-            a = tmp[ 4*(8*idx + k) + 0 ];
-            b = tmp[ 4*(8*idx + k) + 1 ];
-            c = tmp[ 4*(8*idx + k) + 2 ];
-            d = tmp[ 4*(8*idx + k) + 3 ];
+            uint16_t val_a,val_b,val_c,val_d;
+            val_a = tmp[ 4*(8*idx + k) + 0 ];
+            val_b = tmp[ 4*(8*idx + k) + 1 ];
+            val_c = tmp[ 4*(8*idx + k) + 2 ];
+            val_d = tmp[ 4*(8*idx + k) + 3 ];
 
-            tmp_eval[0] = (uint16_t)(   a                   );   /* 0     */
-            tmp_eval[1] = (uint16_t)( 8*a - 4*b + 2*c -   d );   /* -1/2  */
-            tmp_eval[2] = (uint16_t)( 8*a + 4*b + 2*c +   d );   /* +1/2  */
-            tmp_eval[3] = (uint16_t)(   a -   b +   c -   d );   /* -1    */
-            tmp_eval[4] = (uint16_t)(   a +   b +   c +   d );   /* +1    */
-            tmp_eval[5] = (uint16_t)(   a + 2*b + 4*c + 8*d );   /* +2    */
-            tmp_eval[6] = (uint16_t)(                     d );   /* infty */
+            tmp_eval[0] = (uint16_t)(   val_a                   );   /* 0     */
+            tmp_eval[1] = (uint16_t)( 8*val_a - 4*val_b + 2*val_c -   val_d );   /* -1/2  */
+            tmp_eval[2] = (uint16_t)( 8*val_a + 4*val_b + 2*val_c +   val_d );   /* +1/2  */
+            tmp_eval[3] = (uint16_t)(   val_a -   val_b +   val_c -   val_d );   /* -1    */
+            tmp_eval[4] = (uint16_t)(   val_a +   val_b +   val_c +   val_d );   /* +1    */
+            tmp_eval[5] = (uint16_t)(   val_a + 2*val_b + 4*val_c + 8*val_d );   /* +2    */
+            tmp_eval[6] = (uint16_t)(                     val_d );   /* infty */
 
             poly[idx * 4 * 8 + 8*0 + k] = tmp_eval[0];
             poly[idx * 4 * 8 + 8*1 + k] = tmp_eval[1];
@@ -886,16 +886,16 @@ static void poly_u16_toom3_fwd_C( uint16_t *poly )
 
     for( idx = 0; idx < limb_dim; idx++ )
     {
-        uint16_t a,b,c;
-        a = limb[0][idx];
-        b = limb[1][idx];
-        c = limb[2][idx];
+        uint16_t val_a,val_b,val_c;
+        val_a = limb[0][idx];
+        val_b = limb[1][idx];
+        val_c = limb[2][idx];
 
-        eval[0][idx] = (uint16_t)(   a             );
-        eval[1][idx] = (uint16_t)(   a +   b +   c );
-        eval[2][idx] = (uint16_t)(   a -   b +   c );
-        eval[3][idx] = (uint16_t)(   a - 2*b + 4*c );
-        eval[4][idx] = (uint16_t)(               c );
+        eval[0][idx] = (uint16_t)(   val_a             );
+        eval[1][idx] = (uint16_t)(   val_a +   val_b +   val_c );
+        eval[2][idx] = (uint16_t)(   val_a -   val_b +   val_c );
+        eval[3][idx] = (uint16_t)(   val_a - 2*val_b + 4*val_c );
+        eval[4][idx] = (uint16_t)(               val_c );
     }
 }
 
@@ -1466,13 +1466,13 @@ int unfold(test_toom4_fwd_dual_bottom)()
  */
 
 #if defined(TEST_TOOM4_FWD_INV)
-static void multiply_by_eval_of_1_toom4( uint16_t *a )
+static void multiply_by_eval_of_1_toom4( uint16_t *poly_a )
 {
     unsigned limb_dim = DIMENSION / 4;
     unsigned idx, pt_idx;
     MAKE_BUFFER(tmp,16,BUFFER_SIZE,8);
-    make_eval_offsets_toom4( a,   eval_a,   1 );
-    make_prod_offsets_toom4( a,   prod_a,   1 );
+    make_eval_offsets_toom4( poly_a,   eval_a,   1 );
+    make_prod_offsets_toom4( poly_a,   prod_a,   1 );
     make_prod_offsets_toom4( tmp, prod_tmp, 1 );
 
     uint16_t eval_of_one[] = { 1, 8, 8, 1, 1, 1, 0 };
@@ -1537,13 +1537,13 @@ int unfold(test_toom4_fwd_inv)()
 #endif /* TEST_TOOM4_FWD_INV */
 
 #if defined(TEST_TOOM4_FWD_INV_DUAL_PACKED_LIMBS_OOP)
-static void multiply_by_eval_of_1_toom4_dual_packed_limbs_oop( uint16_t *a )
+static void multiply_by_eval_of_1_toom4_dual_packed_limbs_oop( uint16_t *poly_a )
 {
     unsigned limb_dim = DIMENSION / 4;
     unsigned idx, pt_idx;
     MAKE_BUFFER(tmp,16,BUFFER_SIZE,8);
-    make_eval_offsets_toom4_oop( a,   eval_a,   1 );
-    make_prod_offsets_toom4( a,   prod_a,   1 );
+    make_eval_offsets_toom4_oop( poly_a,   eval_a,   1 );
+    make_prod_offsets_toom4( poly_a,   prod_a,   1 );
     make_prod_offsets_toom4( tmp, prod_tmp, 1 );
 
     uint16_t eval_of_one[] = { 1, 8, 8, 1, 1, 1, 0 };
@@ -1609,13 +1609,13 @@ int unfold(test_toom4_fwd_inv_dual_packed_limbs_oop)()
 
 #if defined(TEST_TOOM4_FWD_INV_DUAL_BOTTOM) || \
     defined(TEST_TOOM4_FWD_INV_DUAL_BOTTOM_OOP)
-static void multiply_by_eval_of_1_toom4_dual_bottom( uint16_t *a )
+static void multiply_by_eval_of_1_toom4_dual_bottom( uint16_t *poly_a )
 {
     unsigned limb_dim = DIMENSION_DIV4;
     unsigned idx, pt_idx, k;
     MAKE_BUFFER(tmp,16,BUFFER_SIZE,8);
-    make_eval_offsets_toom4_dual_bottom( a,   eval_a,   1 );
-    make_eval_offsets_toom4_dual_bottom( a,   prod_a,   1 );
+    make_eval_offsets_toom4_dual_bottom( poly_a,   eval_a,   1 );
+    make_eval_offsets_toom4_dual_bottom( poly_a,   prod_a,   1 );
     make_eval_offsets_toom4_dual_bottom( tmp + 3 * DIMENSION_DIV4, prod_tmp, 1 );
 
     uint16_t eval_of_one[] = { 1, 8, 8, 1, 1, 1, 0 };
@@ -1751,13 +1751,13 @@ int unfold(test_toom4_fwd_inv_dual_bottom_oop)()
 
 #if defined(TEST_TOOM4_FWD_INV_DUAL_TOP) || \
     defined(TEST_TOOM4_FWD_INV_DUAL_TOP_OOP)
-static void multiply_by_eval_of_1_toom4_dual_top( uint16_t *a )
+static void multiply_by_eval_of_1_toom4_dual_top( uint16_t *poly_a )
 {
     unsigned limb_dim = DIMENSION_DIV4;
     unsigned idx, pt_idx, k;
     MAKE_BUFFER(tmp,16,BUFFER_SIZE,8);
-    make_eval_offsets_toom4_dual_top( a,   eval_a,   1 );
-    make_eval_offsets_toom4_dual_top( a,   prod_a,   1 );
+    make_eval_offsets_toom4_dual_top( poly_a,   eval_a,   1 );
+    make_eval_offsets_toom4_dual_top( poly_a,   prod_a,   1 );
     make_eval_offsets_toom4_dual_top( tmp, prod_tmp, 1 );
 
     uint16_t eval_of_one[] = { 1, 8, 8, 1, 1, 1, 0 };
@@ -1964,14 +1964,14 @@ int unfold(test_toom3_fwd_inv)()
 
 #if defined(TEST_TOOM4_FWD_MUL_INV)
 
-static void multiply_evals_toom4( uint16_t *c, uint16_t *a, uint16_t *b )
+static void multiply_evals_toom4( uint16_t *poly_c, uint16_t *poly_a, uint16_t *poly_b )
 {
     unsigned limb_dim = DIMENSION / 4;
     unsigned pt_idx;
 
-    make_eval_offsets_toom4( a, eval_a, 1 );
-    make_eval_offsets_toom4( b, eval_b, 1 );
-    make_prod_offsets_toom4( c, prod_c, 2 );
+    make_eval_offsets_toom4( poly_a, eval_a, 1 );
+    make_eval_offsets_toom4( poly_b, eval_b, 1 );
+    make_prod_offsets_toom4( poly_c, prod_c, 2 );
 
     for( pt_idx = 0; pt_idx < 7; pt_idx++ )
     {
@@ -1982,13 +1982,13 @@ static void multiply_evals_toom4( uint16_t *c, uint16_t *a, uint16_t *b )
     }
 }
 
-static void narrow_limbs_toom4( uint16_t *a )
+static void narrow_limbs_toom4( uint16_t *poly_a )
 {
     unsigned limb_dim = DIMENSION / 4;
     unsigned idx, pt_idx;
 
-    make_prod_offsets_toom4( a, a_wide,   2);
-    make_prod_offsets_toom4( a, a_narrow, 1);
+    make_prod_offsets_toom4( poly_a, a_wide,   2);
+    make_prod_offsets_toom4( poly_a, a_narrow, 1);
 
     for( pt_idx = 0; pt_idx < 7; pt_idx++ )
     {
@@ -2045,14 +2045,14 @@ int unfold(test_toom4_fwd_mul_inv)()
 #endif /* TEST_TOOM4_FWD_MUL_INV */
 
 #if defined(TEST_TOOM4_FWD_MUL_INV_DUAL_PACKED_LIMBS_OOP)
-static void multiply_evals_toom4_dual_packed_limbs_oop( uint16_t *c, uint16_t *a, uint16_t *b )
+static void multiply_evals_toom4_dual_packed_limbs_oop( uint16_t *poly_c, uint16_t *poly_a, uint16_t *poly_b )
 {
     unsigned limb_dim = DIMENSION / 4;
     unsigned pt_idx;
 
-    make_eval_offsets_toom4_oop( a, eval_a, 1 );
-    make_eval_offsets_toom4_oop( b, eval_b, 1 );
-    make_prod_offsets_toom4( c, prod_c, 1 );
+    make_eval_offsets_toom4_oop( poly_a, eval_a, 1 );
+    make_eval_offsets_toom4_oop( poly_b, eval_b, 1 );
+    make_prod_offsets_toom4( poly_c, prod_c, 1 );
 
     for( pt_idx = 0; pt_idx < 7; pt_idx++ )
     {
@@ -2104,14 +2104,14 @@ int unfold(test_toom4_fwd_mul_inv_dual_packed_limbs_oop)()
 
 
 #if defined(TEST_TOOM4_FWD_MUL_INV_DUAL_BOTTOM)
-static void multiply_evals_toom4_dual_bottom( uint16_t *c, uint16_t *a, uint16_t *b )
+static void multiply_evals_toom4_dual_bottom( uint16_t *poly_c, uint16_t *poly_a, uint16_t *poly_b )
 {
     unsigned limb_dim = DIMENSION_DIV4;
     unsigned pt_idx;
 
-    make_eval_offsets_toom4_dual_bottom( a, eval_a, 1 );
-    make_eval_offsets_toom4_dual_bottom( b, eval_b, 1 );
-    make_eval_offsets_toom4_dual_bottom( c, prod_c, 1 );
+    make_eval_offsets_toom4_dual_bottom( poly_a, eval_a, 1 );
+    make_eval_offsets_toom4_dual_bottom( poly_b, eval_b, 1 );
+    make_eval_offsets_toom4_dual_bottom( poly_c, prod_c, 1 );
 
     for( pt_idx = 0; pt_idx < 4; pt_idx++ )
     {
@@ -2176,14 +2176,14 @@ int unfold(test_toom4_fwd_mul_inv_dual_bottom)()
 
 #if defined(TEST_TOOM4_FWD_MUL_INV_DUAL_TOP)
 
-static void multiply_evals_toom4_dual_top( uint16_t *c, uint16_t *a, uint16_t *b )
+static void multiply_evals_toom4_dual_top( uint16_t *poly_c, uint16_t *poly_a, uint16_t *poly_b )
 {
     unsigned limb_dim = DIMENSION_DIV4;
     unsigned pt_idx;
 
-    make_eval_offsets_toom4_dual_top( a, eval_a, 1 );
-    make_eval_offsets_toom4_dual_top( b, eval_b, 1 );
-    make_eval_offsets_toom4_dual_top( c, prod_c, 1 );
+    make_eval_offsets_toom4_dual_top( poly_a, eval_a, 1 );
+    make_eval_offsets_toom4_dual_top( poly_b, eval_b, 1 );
+    make_eval_offsets_toom4_dual_top( poly_c, prod_c, 1 );
 
     for( pt_idx = 0; pt_idx < 4; pt_idx++ )
     {

--- a/tests/transpose/main.c
+++ b/tests/transpose/main.c
@@ -78,7 +78,6 @@ void generate_sample()
 
 static int test_transpose()
 {
-    int a[4];
     debug_test_start( "Test: Transpose" );
     generate_simple_sample();
 


### PR DESCRIPTION
- Fixes compiler warnings that prevent clean builds with strict error checking
- Resolves pointer signedness, unused variables, and macro redefinition warnings
- See individual commit messages for detailed changes

Resolves https://github.com/slothy-optimizer/pqmx/issues/15

This work was done by Amazon Q.